### PR TITLE
feat: support overriding repo_ref for testing jumpstart upgrades and …

### DIFF
--- a/src/fabric_jumpstart/CONTRIBUTING.md
+++ b/src/fabric_jumpstart/CONTRIBUTING.md
@@ -11,6 +11,7 @@ This is the most common contribution. You only need to add a single YAML file, r
 3. Keep Jumpstarts self-contained: deployments must run through `jumpstart.install()` without manual patching.
 4. Please read [STANDARDS.md](STANDARDS.md) for Jumpstart design and quality expectations.
 5. Follow the steps in [Setup of a New Jumpstart](#setup-of-a-new-jumpstart) to get things set up, tested, and merged in.
+5. For upgrading existing Jumpstarts, follow the [Upgrading an Existing Jumpstart](#updating-an-existing-jumpstart) guide.
 
 ## Development Setup
 
@@ -89,3 +90,16 @@ uv run pytest tests/test_registry.py  # Registry validation (required for new ju
      - `owner_email`: Valid email address
 1. Run `fabric_jumpstart.install('<logical-id>', workspace_id='<workspace_guid>')` to validate the Jumpstart deploys correctly (see [dev_example.ipynb](../../dev/dev_example.ipynb) for a quick way to test).
 1. Submit a PR with your Jumpstart YAML file.
+
+## Updating an Existing Jumpstart
+
+When a jumpstart's source repository publishes a new tag or ref, you can test the update before submitting a PR:
+
+1. Use the `repo_ref` keyword argument to install with the newer ref without modifying any YAML:
+   ```python
+   import fabric_jumpstart as js
+   js.install('retail-sales', workspace_id='<workspace_guid>', repo_ref='v2.0.0')
+   ```
+2. Validate that the jumpstart deploys and functions correctly with the new ref.
+3. Once verified, update the `repo_ref` value in the jumpstart's YAML file and submit a PR.
+4. Run `uv run pytest tests/test_registry.py` to confirm the new ref is reachable before pushing.

--- a/src/fabric_jumpstart/fabric_jumpstart/core.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/core.py
@@ -181,6 +181,7 @@ class jumpstart:
                 - update_existing: If True, conflicting items will be updated
                 - auto_prefix_on_conflict: If True, auto-generate a prefix when conflicts are detected
                 - debug: If True, include all jumpstart logs (INFO+) in the rendered output; otherwise only fabric-cicd logs
+                - repo_ref: Override the registered source repo_ref (git tag/branch/commit) at runtime
         """
         config = self._get_jumpstart_by_logical_id(name)
         if not config:

--- a/src/fabric_jumpstart/fabric_jumpstart/installer.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/installer.py
@@ -48,6 +48,7 @@ class JumpstartInstaller:
         self.item_prefix = options.get('item_prefix')
         self.unattended = options.get('unattended', False)
         self.debug_logs = bool(options.get('debug', False))
+        self.repo_ref_override = options.get('repo_ref')
         
         # State tracking
         self.log_buffer: List[Dict] = []
@@ -99,7 +100,9 @@ class JumpstartInstaller:
         if 'repo_url' in source_config:
             # Remote jumpstart
             repo_url = source_config['repo_url']
-            repo_ref = source_config.get('repo_ref', 'main')
+            repo_ref = self.repo_ref_override or source_config['repo_ref']
+            if self.repo_ref_override:
+                logger.info(f"Overriding registered repo_ref with '{self.repo_ref_override}'")
             logger.info(f"Cloning from {repo_url} (ref: {repo_ref})")
             self.working_repo_path = clone_repository(
                 repository_url=repo_url,

--- a/src/fabric_jumpstart/tests/test_installer.py
+++ b/src/fabric_jumpstart/tests/test_installer.py
@@ -1,0 +1,46 @@
+"""Tests for repo_ref override in JumpstartInstaller."""
+
+from unittest.mock import patch, MagicMock
+from fabric_jumpstart.installer import JumpstartInstaller
+
+
+def _make_config(**overrides):
+    """Return a minimal jumpstart config dict."""
+    config = {
+        "id": 1,
+        "logical_id": "test-jumpstart",
+        "source": {
+            "repo_url": "https://github.com/example/repo.git",
+            "repo_ref": "v1.0.0",
+            "workspace_path": "demo/",
+            "preview_image_path": "demo/preview.png",
+        },
+    }
+    config.update(overrides)
+    return config
+
+
+@patch("fabric_jumpstart.installer.clone_repository")
+def test_prepare_workspace_uses_config_repo_ref_by_default(mock_clone):
+    """Without repo_ref kwarg, the registered config value is used."""
+    mock_clone.return_value = MagicMock()
+    installer = JumpstartInstaller(_make_config(), workspace_id="ws-123", instance_name="js")
+    installer.prepare_workspace()
+
+    mock_clone.assert_called_once()
+    _, kwargs = mock_clone.call_args
+    assert kwargs["ref"] == "v1.0.0"
+
+
+@patch("fabric_jumpstart.installer.clone_repository")
+def test_prepare_workspace_uses_repo_ref_override(mock_clone):
+    """When repo_ref kwarg is provided, it overrides the config value."""
+    mock_clone.return_value = MagicMock()
+    installer = JumpstartInstaller(
+        _make_config(), workspace_id="ws-123", instance_name="js", repo_ref="v2.0.0-beta"
+    )
+    installer.prepare_workspace()
+
+    mock_clone.assert_called_once()
+    _, kwargs = mock_clone.call_args
+    assert kwargs["ref"] == "v2.0.0-beta"


### PR DESCRIPTION
# Why this change is needed
…patching outside of jumpstart release windows. sometimes a newer repo_ref is needed to patch jumpstarts before an event or lab, there needs to be an option to prevent jumpstart release schedules from blocking using jumpstart for the deployment.

# Test

all tests pass

# Closes issue

closes #62 