### PR TITLE
Latest Changes for RTI Jumpstarts

### DIFF
--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/banking-loan-fraud.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/banking-loan-fraud.yml
@@ -15,7 +15,7 @@ scenario_tags:
 type: Demo
 source:
   repo_url: https://github.com/ecotte/fabric-rti-demos.git
-  repo_ref: v0.1.4
+  repo_ref: v0.1.8
   workspace_path: banking-loan-fraud/
   preview_image_path: banking-loan-fraud/BankingLoanFraud.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-activity-events.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-activity-events.yml
@@ -16,7 +16,7 @@ scenario_tags:
 type: Accelerator
 source:
   repo_url: https://github.com/ecotte/fabric-platform-monitoring.git
-  repo_ref: v0.2.1
+  repo_ref: v0.2.3
   workspace_path: activity-events/src/
   preview_image_path: activity-events/ActivityEvents.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-capacity-events.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-capacity-events.yml
@@ -15,7 +15,7 @@ scenario_tags:
 type: Accelerator
 source:
   repo_url: https://github.com/ecotte/fabric-platform-monitoring.git
-  repo_ref: v0.2.1
+  repo_ref: v0.2.3
   workspace_path: capacity-events/src/
   preview_image_path: capacity-events/CapacityEvents.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-fabric-inventory.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-fabric-inventory.yml
@@ -15,7 +15,7 @@ scenario_tags:
 type: Accelerator
 source:
   repo_url: https://github.com/ecotte/fabric-platform-monitoring.git
-  repo_ref: v0.2.1
+  repo_ref: v0.2.3
   workspace_path: fabric-inventory/src/
   preview_image_path: fabric-inventory/FabricInventory.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-gateway-monitoring.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-gateway-monitoring.yml
@@ -16,7 +16,7 @@ scenario_tags:
 type: Accelerator
 source:
   repo_url: https://github.com/ecotte/fabric-platform-monitoring.git
-  repo_ref: v0.2.1
+  repo_ref: v0.2.3
   workspace_path: gateway-monitoring/src/
   preview_image_path: gateway-monitoring/GatewayMonitoring.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-workspace-item-events.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/fpm-workspace-item-events.yml
@@ -16,7 +16,7 @@ scenario_tags:
 type: Accelerator
 source:
   repo_url: https://github.com/ecotte/fabric-platform-monitoring.git
-  repo_ref: v0.2.2
+  repo_ref: v0.2.3
   workspace_path: workspace-item-events/src/
   preview_image_path: workspace-item-events/WorkspaceItemEvents.png
 items_in_scope: 

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/healthcare-billing-system.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/healthcare-billing-system.yml
@@ -15,7 +15,7 @@ scenario_tags:
 type: Demo
 source:
   repo_url: https://github.com/ecotte/fabric-rti-demos.git
-  repo_ref: v0.1.2
+  repo_ref: v0.1.8
   workspace_path: healthcare-billing-system/
   preview_image_path: healthcare-billing-system/HealthcareBillingSystem.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/retail-sales.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/retail-sales.yml
@@ -14,7 +14,7 @@ scenario_tags:
 type: Demo
 source:
   repo_url: https://github.com/ecotte/fabric-rti-demos.git
-  repo_ref: v0.1.5
+  repo_ref: v0.1.8
   workspace_path: retail-sales/
   preview_image_path: retail-sales/RetailSales.png
 items_in_scope:

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/spark-monitoring-and-optimization.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/spark-monitoring-and-optimization.yml
@@ -1,12 +1,12 @@
-id: 4
-logical_id: spark-rti-monitoring
-name: Spark RTI Monitoring
+id: 19
+logical_id: spark-monitoring-and-optimization
+name: Spark Monitoring and Optimization
 description: >-
-  Empower your Spark workloads with real-time monitoring using Fabric Real-Time
+  Empower your Spark workloads monitoring using Fabric Real-Time
   Intelligence. Track Spark job performance metrics, visualize data streams on
   live dashboards, and gain operational insights to optimize your data
   engineering pipelines.
-date_added: 9/1/2025
+date_added: 3/3/2026
 include_in_listing: false
 workload_tags:
 - Data Engineering
@@ -15,10 +15,10 @@ scenario_tags:
 - Monitoring
 type: Accelerator
 source:
-  repo_url: https://github.com/microsoft/fabric-toolbox.git
-  repo_ref: main
-  workspace_path: monitoring/fabric-spark-monitoring/src/
-  preview_image_path: monitoring/fabric-spark-monitoring/assets/image-example.png
+  repo_url: https://github.com/ecotte/fabric-platform-monitoring.git
+  repo_ref: v0.2.5
+  workspace_path: spark-monitoring/src/
+  preview_image_path: spark-monitoring/image-example.png
 items_in_scope:
 - Notebook
 - Eventhouse
@@ -28,14 +28,13 @@ items_in_scope:
 - KQLQueryset
 - Environment
 - DataPipeline
-- Report
-- SemanticModel
+- DataAgent
 jumpstart_docs_uri: ''
-entry_point: 1_ExploreData.Notebook
+entry_point: Fabric Spark Monitoring Setup.Notebook
 test_suite: ''
 owner_email: FabricJumpstart.SparkRTIMonitoring@microsoft.com
 minutes_to_deploy: 3
 minutes_to_complete_jumpstart: 20
 video_url: ""
 difficulty: "Intermediate"
-last_updated: "2025-09-01"
+last_updated: "2026-03-03"

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/telecom-call-data-records.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/telecom-call-data-records.yml
@@ -1,0 +1,34 @@
+id: 20
+logical_id: telecom-call-data-records
+name: Real-Time Telecom Call Data Records
+description: >-
+  Monitor real-time telecom call data records using Fabric Real-Time Intelligence.
+  Stream call data through Eventstream into an Eventhouse and visualize usage
+  patterns on live KQL dashboards.
+date_added: 03/03/2026
+include_in_listing: true
+workload_tags:
+- Real-Time Intelligence
+scenario_tags:
+- Streaming
+type: Demo
+source:
+  repo_url: https://github.com/ecotte/fabric-rti-demos.git
+  repo_ref: v0.1.8
+  workspace_path: telecom-call-data-records/
+  preview_image_path: telecom-call-data-records/TelecomCallDataRecords.png
+items_in_scope:
+- Notebook
+- Eventhouse
+- Eventstream
+- KQLDatabase
+- KQLDashboard
+jumpstart_docs_uri: ''
+entry_point: TelecomCallDataRecordsEmulator.Notebook
+test_suite: ''
+owner_email: fabricjumpstart.rti-iq@microsoft.com
+minutes_to_deploy: 2
+minutes_to_complete_jumpstart: 5
+video_url: ""
+difficulty: "Beginner"
+last_updated: "2026-03-03"


### PR DESCRIPTION
> [!NOTE]
> Thank you for making change! Please consider filling this template for your pull request to improve quality of checkin message.

> [!TIP]
> This repo uses [Conventional Commit conventions](https://www.conventionalcommits.org/en/v1.0.0/) - please try to rename your PR headline to match it.

# Why this change is needed

Describe what issue this change is trying to address.

- Issues with the Semantic Link Lab version not been fixed in the RTI Accelerators
- Issue with Eventstream and Direct Ingest to Eventhouse when the Stream name was not the same as the Eventstream

# How

Describe how the change works.

- Fixed the version of SLL in the notebooks for accelerators
- Changed the name of the stream to match the Eventstream

# Test

- Create the new version
- Added the version to the jumpstart
- Deployed with the new jumpstart

