### PR TITLE
fix: update analytics-roadshow-lab docs URI to v0.1.3

### DIFF
--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/analytics-roadshow-lab.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/analytics-roadshow-lab.yml
@@ -29,7 +29,7 @@ items_in_scope:
 - DataPipeline
 feature_flags:
 - enable_lakehouse_unpublish
-jumpstart_docs_uri: https://github.com/microsoft/fabric-analytics-roadshow-lab/blob/v0.1.1/README.md
+jumpstart_docs_uri: https://github.com/microsoft/fabric-analytics-roadshow-lab/blob/v0.1.3/README.md
 entry_point: 1_process_data.Notebook
 test_suite: ''
 owner_email: FabricJumpstart.AnalyticsRoadshowLab@microsoft.com


### PR DESCRIPTION
# Why this change is needed

The `jumpstart_docs_uri` for the analytics-roadshow-lab jumpstart was pointing to v0.1.1 while the `repo_ref` was updated to v0.1.3. This caused the documentation link to point to outdated documentation.

- Bug discovered when deploying the jumpstart and noticing the docs pointed to the wrong release.

# How

Updated `jumpstart_docs_uri` from v0.1.1 to v0.1.3 to match the current `repo_ref`.

# Test

- Ran `uv run pytest tests/test_registry.py` - all 30 tests passed