### PR TITLE
feat: update jumpstart_docs_uri when repo_ref is overridden

### DIFF
--- a/src/fabric_jumpstart/fabric_jumpstart/core.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/core.py
@@ -211,7 +211,7 @@ class jumpstart:
                 entry_point=entry,
                 minutes_complete=config.get('minutes_to_complete_jumpstart'),
                 minutes_deploy=config.get('minutes_to_deploy'),
-                docs_uri=config.get('jumpstart_docs_uri'),
+                docs_uri=installer.effective_docs_uri,
                 logs=log_buffer,
                 error_message=err,
                 extra_html=extra_html,
@@ -314,7 +314,7 @@ class jumpstart:
                     entry_point=entry_url,
                     minutes_complete=config.get('minutes_to_complete_jumpstart'),
                     minutes_deploy=config.get('minutes_to_deploy'),
-                    docs_uri=config.get('jumpstart_docs_uri'),
+                    docs_uri=installer.effective_docs_uri,
                     logs=log_buffer,
                 )
                 
@@ -366,7 +366,7 @@ class jumpstart:
                     entry_point=config.get('entry_point'),
                     minutes_complete=config.get('minutes_to_complete_jumpstart'),
                     minutes_deploy=config.get('minutes_to_deploy'),
-                    docs_uri=config.get('jumpstart_docs_uri'),
+                    docs_uri=installer.effective_docs_uri,
                     logs=log_buffer,
                     error_message=error_text,
                 )

--- a/src/fabric_jumpstart/fabric_jumpstart/installer.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/installer.py
@@ -13,6 +13,7 @@ from .utils import (
     _is_fabric_runtime,
     clone_files_to_temp_directory,
     clone_repository,
+    update_docs_uri_with_ref,
 )
 from .workspace_manager import WorkspaceManager
 
@@ -57,6 +58,16 @@ class JumpstartInstaller:
         self.workspace_manager: Optional[WorkspaceManager] = None
         self.had_conflicts = False
         self.resolved_prefix: Optional[str] = None
+
+    @property
+    def effective_docs_uri(self) -> Optional[str]:
+        """Get the docs URI, adjusted for repo_ref override if applicable."""
+        docs_uri = self.config.get('jumpstart_docs_uri')
+        if self.repo_ref_override:
+            source_config = self.config.get('source', {})
+            original_ref = source_config.get('repo_ref', '')
+            return update_docs_uri_with_ref(docs_uri, original_ref, self.repo_ref_override)
+        return docs_uri
     
     def validate(self) -> str:
         """Validate configuration and resolve workspace ID.

--- a/src/fabric_jumpstart/fabric_jumpstart/utils.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/utils.py
@@ -217,6 +217,41 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
     )
     return mappings
 
+
+def update_docs_uri_with_ref(
+    docs_uri: Optional[str],
+    original_ref: str,
+    new_ref: str
+) -> Optional[str]:
+    """Update the docs URI to use a new git reference.
+
+    Only updates GitHub blob URLs that contain the original_ref in the path.
+    Other URLs (external sites, empty strings) are returned unchanged.
+
+    Args:
+        docs_uri: The original jumpstart_docs_uri from config
+        original_ref: The original repo_ref from config (e.g., 'v0.1.1')
+        new_ref: The new repo_ref to use (e.g., 'v0.1.3')
+
+    Returns:
+        Updated docs URI with new_ref, or original if not applicable
+    """
+    if not docs_uri or not original_ref or not new_ref:
+        return docs_uri
+    if original_ref == new_ref:
+        return docs_uri
+    # Only update GitHub blob URLs that contain the original ref
+    # Pattern: https://github.com/{owner}/{repo}/blob/{ref}/...
+    if 'github.com' in docs_uri and '/blob/' in docs_uri:
+        old_pattern = f'/blob/{original_ref}/'
+        new_pattern = f'/blob/{new_ref}/'
+        if old_pattern in docs_uri:
+            updated_uri = docs_uri.replace(old_pattern, new_pattern)
+            logger.info(f"Updated docs URI from '{original_ref}' to '{new_ref}'")
+            return updated_uri
+    return docs_uri
+
+
 def clone_repository(
     repository_url: str,
     ref: Optional[str] = None,

--- a/src/fabric_jumpstart/tests/test_installer.py
+++ b/src/fabric_jumpstart/tests/test_installer.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch, MagicMock
 from fabric_jumpstart.installer import JumpstartInstaller
+from fabric_jumpstart.utils import update_docs_uri_with_ref
 
 
 def _make_config(**overrides):
@@ -44,3 +45,86 @@ def test_prepare_workspace_uses_repo_ref_override(mock_clone):
     mock_clone.assert_called_once()
     _, kwargs = mock_clone.call_args
     assert kwargs["ref"] == "v2.0.0-beta"
+
+
+def test_effective_docs_uri_returns_original_when_no_override():
+    """Without repo_ref override, effective_docs_uri returns the original."""
+    config = _make_config(jumpstart_docs_uri="https://github.com/example/repo/blob/v1.0.0/README.md")
+    installer = JumpstartInstaller(config, workspace_id="ws-123", instance_name="js")
+    assert installer.effective_docs_uri == "https://github.com/example/repo/blob/v1.0.0/README.md"
+
+
+def test_effective_docs_uri_updates_github_blob_url_with_override():
+    """When repo_ref override is provided, GitHub blob URLs are updated."""
+    config = _make_config(jumpstart_docs_uri="https://github.com/example/repo/blob/v1.0.0/README.md")
+    installer = JumpstartInstaller(
+        config, workspace_id="ws-123", instance_name="js", repo_ref="v2.0.0"
+    )
+    assert installer.effective_docs_uri == "https://github.com/example/repo/blob/v2.0.0/README.md"
+
+
+def test_effective_docs_uri_preserves_non_github_urls():
+    """Non-GitHub URLs are returned unchanged even with repo_ref override."""
+    config = _make_config(jumpstart_docs_uri="https://jumpstart.fabric.microsoft.com/docs/")
+    installer = JumpstartInstaller(
+        config, workspace_id="ws-123", instance_name="js", repo_ref="v2.0.0"
+    )
+    assert installer.effective_docs_uri == "https://jumpstart.fabric.microsoft.com/docs/"
+
+
+def test_effective_docs_uri_handles_empty_string():
+    """Empty docs_uri is returned unchanged."""
+    config = _make_config(jumpstart_docs_uri="")
+    installer = JumpstartInstaller(
+        config, workspace_id="ws-123", instance_name="js", repo_ref="v2.0.0"
+    )
+    assert installer.effective_docs_uri == ""
+
+
+def test_effective_docs_uri_handles_none():
+    """None docs_uri is returned unchanged."""
+    config = _make_config()  # No jumpstart_docs_uri
+    installer = JumpstartInstaller(
+        config, workspace_id="ws-123", instance_name="js", repo_ref="v2.0.0"
+    )
+    assert installer.effective_docs_uri is None
+
+
+# Tests for update_docs_uri_with_ref utility function
+
+def test_update_docs_uri_with_ref_basic():
+    """Basic replacement of ref in GitHub blob URL."""
+    result = update_docs_uri_with_ref(
+        "https://github.com/microsoft/repo/blob/v1.0.0/README.md",
+        "v1.0.0",
+        "v2.0.0"
+    )
+    assert result == "https://github.com/microsoft/repo/blob/v2.0.0/README.md"
+
+
+def test_update_docs_uri_with_ref_same_ref():
+    """Returns original when refs are the same."""
+    original = "https://github.com/microsoft/repo/blob/v1.0.0/README.md"
+    result = update_docs_uri_with_ref(original, "v1.0.0", "v1.0.0")
+    assert result == original
+
+
+def test_update_docs_uri_with_ref_non_github():
+    """Non-GitHub URLs are unchanged."""
+    original = "https://docs.example.com/readme"
+    result = update_docs_uri_with_ref(original, "v1.0.0", "v2.0.0")
+    assert result == original
+
+
+def test_update_docs_uri_with_ref_github_without_blob():
+    """GitHub URLs without /blob/ are unchanged."""
+    original = "https://github.com/microsoft/repo"
+    result = update_docs_uri_with_ref(original, "v1.0.0", "v2.0.0")
+    assert result == original
+
+
+def test_update_docs_uri_with_ref_ref_not_in_url():
+    """Returns original if the original ref is not in the URL."""
+    original = "https://github.com/microsoft/repo/blob/main/README.md"
+    result = update_docs_uri_with_ref(original, "v1.0.0", "v2.0.0")
+    assert result == original


### PR DESCRIPTION
# Why this change is needed

When using the `repo_ref` parameter to test a new version of a jumpstart before updating the YAML file (as documented in the CONTRIBUTING guide), the `jumpstart_docs_uri` would still point to the old version. This could confuse users who follow the documentation link expecting to see docs for the version they're testing.

For example:
- YAML has `repo_ref: v0.1.1` and `jumpstart_docs_uri: .../blob/v0.1.1/README.md`
- User runs `js.install('my-jumpstart', repo_ref='v0.1.3')`
- Previously: docs link still showed v0.1.1 README
- Now: docs link automatically updates to v0.1.3 README

# How

Added a utility function `update_docs_uri_with_ref()` that detects GitHub blob URLs and replaces the version reference. The `JumpstartInstaller` class now exposes an `effective_docs_uri` property that returns the adjusted URL when `repo_ref` override is active.

The change only affects GitHub blob URLs (`/blob/{ref}/`) - other URLs like external documentation sites are preserved unchanged.

# Test

- Added 10 new unit tests covering:
  - Basic URL replacement
  - Handling of same ref (no change needed)
  - Preservation of non-GitHub URLs
  - Preservation of GitHub URLs without `/blob/`
  - Edge cases (empty string, None)
- All 81 tests pass
- Linting and type checking pass