### PR TITLE
feat: Implement file upload functionality to Lakehouse

### DIFF
--- a/src/fabric_jumpstart/CONTRIBUTING.md
+++ b/src/fabric_jumpstart/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This is the most common contribution. You only need to add a single YAML file, r
 3. Keep Jumpstarts self-contained: deployments must run through `jumpstart.install()` without manual patching.
 4. Please read [STANDARDS.md](STANDARDS.md) for Jumpstart design and quality expectations.
 5. Follow the steps in [Setup of a New Jumpstart](#setup-of-a-new-jumpstart) to get things set up, tested, and merged in.
-5. For upgrading existing Jumpstarts, follow the [Upgrading an Existing Jumpstart](#updating-an-existing-jumpstart) guide.
+6. For upgrading existing Jumpstarts, follow the [Upgrading an Existing Jumpstart](#updating-an-existing-jumpstart) guide.
 
 ## Development Setup
 
@@ -29,15 +29,17 @@ $GIT_ROOT = git rev-parse --show-toplevel
 This installs [uv](https://docs.astral.sh/uv/) and the following VS Code extensions: Ruff, Pylance, and Jupyter. After installation it runs `uv sync --all-groups` so you are all set to start contributing!
 
 ## Development
+
 See the [/src/fabric_jumpstart/dev/test_example.ipynb](./dev/test_example.ipynb) notebook for an example of how you can interactively test your Jumpstart.
+
 - Develop in notebooks or `.py` files; restart the Python kernel after code changes so the notebook picks up fresh imports. Or, use `importlib` to reload specific modules for agile testing:
-    ```python
-    import importlib
-    import fabric_jumpstart as jumpstart
-    importlib.reload(jumpstart.core)
-    importlib.reload(jumpstart.utils)
-    importlib.reload(jumpstart)
-    ```
+  ```python
+  import importlib
+  import fabric_jumpstart as jumpstart
+  importlib.reload(jumpstart.core)
+  importlib.reload(jumpstart.utils)
+  importlib.reload(jumpstart)
+  ```
 
 ## Quality Checks
 
@@ -69,6 +71,7 @@ uv run pytest tests/test_registry.py  # Registry validation (required for new ju
    - Any data stores that need to be shared across Jumpstarts (i.e. for modules of an overall solution like Fabric Platform Monitoring) must be stored in a top-level folder called `shared-data-stores`. Otherwise, the Jumpstarts should self contain all Items in the single top-level folder (e.g. `spark-monitoring`).
    - Fabric items must not contain a solution prefix; Jumpstart can optionally add an automatic prefix at deployment (e.g., `js1_sm__`) so multiple Jumpstarts can coexist in the event of conflicting Item names. By default, no prefixing takes place, users need to opt-in to this upon being notified of Item name conflicts.
    - Do **not** use spaces in item names. Item names must either be `lower_case_snake_case` or `ProperCamelCase`. Both of these options accomodate all known naming restrictions.
+   - If your Jumpstart needs small data files uploaded to a Lakehouse's Files area, include them in the source repo and configure the `files_source_path`, `files_destination_lakehouse`, and (optionally) `files_destination_path` fields in the YAML `source` block. The upload runs automatically after item deployment.
 1. Commit items to the repo.
 1. Fork the fabric-jumpstart repo.
 1. Create a new YAML file in `src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/` (or `core/` for Microsoft-sponsored jumpstarts):
@@ -84,7 +87,10 @@ uv run pytest tests/test_registry.py  # Registry validation (required for new ju
      - `workload_tags`: List of valid workload tags
      - `scenario_tags`: List of valid scenario tags
      - `type`: One of: Tutorial, Demo, Accelerator
-     - `source`: Object with `repo_url`, `repo_ref`, `workspace_path`, `preview_image_path`
+     - `source`: Object with `repo_url`, `repo_ref`, `workspace_path`, `preview_image_path`, and optional file upload fields:
+       - `files_source_path` _(optional)_: Relative path within the repo to a file or folder to upload to a Lakehouse's Files area (e.g., `retail-sales/data/`)
+       - `files_destination_lakehouse` _(optional)_: Name of the target Lakehouse (must be deployed by the jumpstart). Required if `files_source_path` is set.
+       - `files_destination_path` _(optional)_: Destination path within the Lakehouse Files area (defaults to root if omitted)
      - `items_in_scope`: List of Fabric item types in scope for deployment (e.g., Lakehouse, Notebook)
      - `entry_point`: Either a URL or `<name>.<item_type>` format
      - `owner_email`: Valid email address

--- a/src/fabric_jumpstart/README.md
+++ b/src/fabric_jumpstart/README.md
@@ -28,22 +28,27 @@ jumpstart.install("spark-structured-streaming")
 ```
 
 Notes
+
 - `workspace_id` is optional when you run in a Fabric notebook; it auto-detects the current workspace. Specify to deploy to another target workspace.
 - `install()` accepts extras like `item_prefix` and `unattended=True` if you prefer console logs over HTML output.
+- Jumpstarts that include file upload configuration will automatically upload small data files to a Lakehouse's Files area after deployment — no extra arguments needed.
 
 ## Handling Name Conflicts
 
 If items with the same name already exist in your workspace, Fabric Jumpstart will detect conflicts and provide resolution options:
 
 1. **Overwrite existing items**:
+
    ```python
    jumpstart.install("spark-structured-streaming", overwrite=True)
    ```
 
 2. **Auto-generate a prefix** to avoid conflicts:
+
    ```python
    jumpstart.install("spark-structured-streaming", auto_prefix_on_conflict=True)
    ```
+
    This generates a prefix like `js3_sss__` (jumpstart ID + abbreviated name) and applies it to all deployed items.
 
 3. **Provide a custom prefix**:
@@ -52,6 +57,7 @@ If items with the same name already exist in your workspace, Fabric Jumpstart wi
    ```
 
 The prefixing strategy:
+
 - Renames item directories (e.g., `MyNotebook.Notebook` → `js3_sss__MyNotebook.Notebook`)
 - Updates all references to renamed items within configuration files
 - Uses word-boundary matching to avoid double-prefixing if you re-run the same install

--- a/src/fabric_jumpstart/STANDARDS.md
+++ b/src/fabric_jumpstart/STANDARDS.md
@@ -1,19 +1,24 @@
 # Core Standards
+
 - Jumpstarts are mature and tested Fabric accelerators, demos, and tutorials.
 - With limited exception, Jumpstarts must be complete solutions as deployed via `jumpstart.install(<jumpstart-id>)`. Unless currently impossible to completely automate, the entirety of the solution must be configured through the installation process.
-    - Data must also be self-contained as part of what the Jumpstart deploys. Consider triggering data generators like `LakeGen` or public data sources.
-    - Jumpstart will support deploying small data files, but the feature is not yet supported #19.
-    - Jumpstart will support a pre/post deployment script concept, this feature is not yet supported #20.
+  - Data must also be self-contained as part of what the Jumpstart deploys. Consider triggering data generators like `LakeGen` or public data sources.
+  - Jumpstarts can upload small files (or folders) from the source repository to a Lakehouse's Files area after deployment. Configure this via the optional `files_source_path`, `files_destination_lakehouse`, and `files_destination_path` fields in the YAML `source` block. Keep uploaded data small — the source repository should remain lightweight.
+  - Jumpstart will support a pre/post deployment script concept, this feature is not yet supported #20.
 - Jumpstarts do not automatically trigger Fabric Items (i.e. Pipelines, Notebooks, etc.) to run after installation. A Notebook with robust markdown instructions should be included in the installation that will reference any user actions.
-    - Where Notebooks reference to do something with another Fabric Item, dynamic links should be used (use param replacement to generate dynamic link)
+  - Where Notebooks reference to do something with another Fabric Item, dynamic links should be used (use param replacement to generate dynamic link)
 
 ## Choosing a GitHub repo for your Jumpstart
+
 The source repository should be lightweight to avoid cloning a single branch taking more than a second or two.
+
 - Remote Jumpstarts must have a `repo_ref` that is a commit ID or ideally a tag version number (i.e. `v1.0.0`). Branch references will not be allowed so that code drift doesn't occur without a PR to the fabric-jumpstart repo to note the changes and allow for testing of the source code before the library distribution is updated.
-> Complex Jumpstarts should be self-contained in an isolated repository. Small Jumpstarts may be grouped into shared respositories, provided that the overall Project is small in size and has clear governance.
+  > Complex Jumpstarts should be self-contained in an isolated repository. Small Jumpstarts may be grouped into shared respositories, provided that the overall Project is small in size and has clear governance.
 
 # Jumpstart Entry Points
+
 The `entry_point` of the Jumpstart is where "Get Started" button links to. This is the starting place for the user to experience the Jumsptart. It must be extremely obvious what the user needs to do, and therefore must be something supporting rich documentation and text, such as a notebook or a documentation web page. For example, if the `entry_point` is a Notebook, it should:
+
 - reference the name of the Jumpstart
 - reference the objectives of the Jumpstart
 - reference any actions the user must take (if the `entry_point` is a data emulator notebook, make it explicitly clear what the notebook does and that the user needs to run it!)
@@ -21,12 +26,16 @@ The `entry_point` of the Jumpstart is where "Get Started" button links to. This 
 - look professional!
 
 ## Self-Documenting Source Code
+
 Source code should be self-documenting where possible.
+
 - Notebooks should self contain robust instructions via markdown. Do not reference instructions in Word documents OR in markdown files from source repositories.
 
 ## Jumpstart Ownership
+
 - Each Jumpstart will be owned by a mail enabled security group (i.e. `fabricjumpstart.spark-structured-streaming@microsoft.com`).That group will have at least two owners.
 - The group will be automatically notificed if the nightly Jumpstart CI build fails. The owners are expected to remediate any code changes ASAP as Jumpstarts with failing test cases (deployment or post-deployment solution validation) will automatically be excluded from what each new release published to PyPi to limit the possibility of users executing Jumpstarts that are known to be in a failing state.
 
 ## Unlisted vs. Listed Jumpstarts
+
 Jumpstarts with the `include_in_listing: False` config won't show up when listing Jumpstarts. These are _unlisted_, not meant for general discoverability. These Jumpstarts will adhere to the same rigor as listed Jumpstarts.

--- a/src/fabric_jumpstart/fabric_jumpstart/core.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/core.py
@@ -12,9 +12,10 @@ from .ui import ConflictUI, render_install_status_html, render_jumpstart_list
 
 logger = logging.getLogger(__name__)
 
+
 class jumpstart:
     """Main jumpstart interface for discovering and installing jumpstarts."""
-    
+
     def __init__(self):
         """Initialize jumpstart with registry."""
         self._registry_manager = JumpstartRegistry()
@@ -28,41 +29,49 @@ class jumpstart:
         """Display all available jumpstarts."""
         print("Available jumpstarts:")
         for j in self._registry:
-            if j.get('include_in_listing', True):
-                logical_id = j.get('logical_id', j.get('id', 'unknown'))
-                numeric_id = j.get('id', '?')
-                print(f"  • {logical_id} (#{numeric_id}): {j.get('name', 'Unknown')} - {j.get('description', 'No description')}")
+            if j.get("include_in_listing", True):
+                logical_id = j.get("logical_id", j.get("id", "unknown"))
+                numeric_id = j.get("id", "?")
+                print(
+                    f"  • {logical_id} (#{numeric_id}): {j.get('name', 'Unknown')} - {j.get('description', 'No description')}"
+                )
 
     def list(self, **kwargs):
         """Display an interactive HTML UI of available jumpstarts."""
         from IPython.display import HTML, display
-        
+
         # Get the instance variable name dynamically
         instance_name = self._get_instance_name()
-        
+
         # Filter jumpstarts that should be listed
         show_unlisted = kwargs.get("show_unlisted", False)
-        jumpstarts = [j for j in self._registry if j.get("include_in_listing", True) or show_unlisted]
-        
+        jumpstarts = [
+            j
+            for j in self._registry
+            if j.get("include_in_listing", True) or show_unlisted
+        ]
+
         # Determine NEW threshold (60 days ago)
         new_threshold = datetime.now() - timedelta(days=60)
-        
+
         # Mark and sort jumpstarts
         for j in jumpstarts:
             try:
-                date_added = datetime.strptime(j['date_added'], "%m/%d/%Y")
-                j['is_new'] = date_added >= new_threshold
+                date_added = datetime.strptime(j["date_added"], "%m/%d/%Y")
+                j["is_new"] = date_added >= new_threshold
             except (ValueError, KeyError):
-                j['is_new'] = False
-        
+                j["is_new"] = False
+
         # Sort: NEW first, then numeric id, then logical_id for stability
-        jumpstarts.sort(key=lambda x: (not x['is_new'], x.get('id', 0), x.get('logical_id', '')))
-        
+        jumpstarts.sort(
+            key=lambda x: (not x["is_new"], x.get("id", 0), x.get("logical_id", ""))
+        )
+
         # Group by scenario, workload, and type
         grouped_scenario = {}
         grouped_workload = {}
         grouped_type = {}
-        
+
         for j in jumpstarts:
             # Group by scenario
             scenario_tags = j.get("scenario_tags", ["Uncategorized"])
@@ -70,7 +79,7 @@ class jumpstart:
                 if tag not in grouped_scenario:
                     grouped_scenario[tag] = []
                 grouped_scenario[tag].append(j)
-            
+
             # Group by workload
             workload_tags = j.get("workload_tags", ["Uncategorized"])
             for tag in workload_tags:
@@ -80,15 +89,18 @@ class jumpstart:
 
             type_tag = j.get("type") or "Unspecified"
             grouped_type.setdefault(type_tag, []).append(j)
-        
+
         # Generate and display HTML
-        html = render_jumpstart_list(grouped_scenario, grouped_workload, grouped_type, instance_name)
+        html = render_jumpstart_list(
+            grouped_scenario, grouped_workload, grouped_type, instance_name
+        )
         display(HTML(html))
-    
+
     def _get_instance_name(self):
         """Get the variable name of this jumpstart instance."""
         import inspect
         import re
+
         current = inspect.currentframe()
         caller = current.f_back if current else None
 
@@ -109,21 +121,27 @@ class jumpstart:
                 for var_name, var_value in scope.items():
                     if var_name == "self":
                         continue
-                    if var_value is self and not var_name.startswith('_'):
+                    if var_value is self and not var_name.startswith("_"):
                         instance_names.add(var_name)
                     # Handle "import fabric_jumpstart as js" where js.jumpstart is the instance
                     try:
-                        if inspect.ismodule(var_value) and getattr(var_value, "jumpstart", None) is self:
+                        if (
+                            inspect.ismodule(var_value)
+                            and getattr(var_value, "jumpstart", None) is self
+                        ):
                             module_aliases.add(var_name)
                     except Exception:
                         # Best-effort alias detection; ignore inspection issues
                         pass
 
-        logger.debug(f"Found instance names: {instance_names}; module aliases: {module_aliases}")
+        logger.debug(
+            f"Found instance names: {instance_names}; module aliases: {module_aliases}"
+        )
 
         # Parse the calling line to see which name was used (favor outer frames first)
         try:
             import linecache
+
             for frame in frames:
                 if not frame or not frame.f_code:
                     continue
@@ -134,9 +152,9 @@ class jumpstart:
                 logger.debug(f"Parsing line: {line}")
 
                 patterns = [
-                    r'(\w+)\.list\s*\(',
-                    r'(\w+)\._get_instance_name\s*\(',
-                    r'(\w+)\.install\s*\(',
+                    r"(\w+)\.list\s*\(",
+                    r"(\w+)\._get_instance_name\s*\(",
+                    r"(\w+)\.install\s*\(",
                 ]
 
                 for pattern in patterns:
@@ -144,7 +162,10 @@ class jumpstart:
                     if match:
                         calling_var = match.group(1)
                         logger.debug(f"Found calling variable: {calling_var}")
-                        if calling_var in instance_names or calling_var in module_aliases:
+                        if (
+                            calling_var in instance_names
+                            or calling_var in module_aliases
+                        ):
                             logger.debug(f"Using matched variable name: {calling_var}")
                             return calling_var
 
@@ -190,7 +211,7 @@ class jumpstart:
 
         instance_name = self._get_instance_name()
         installer = JumpstartInstaller(config, workspace_id, instance_name, **kwargs)
-        
+
         # Setup state for rendering
         unattended = installer.unattended
         log_buffer = installer.log_buffer
@@ -199,19 +220,21 @@ class jumpstart:
         live_rendering = False
         conflict_already_rendered = False
 
-        def _update_live(status_label='installing', entry=None, err=None, extra_html=None):
+        def _update_live(
+            status_label="installing", entry=None, err=None, extra_html=None
+        ):
             """Update live display with current status."""
             if not live_handle or HTML_cls is None:
                 return
             html = render_install_status_html(
                 status=status_label,
-                jumpstart_name=config.get('name', name),
-                type=config.get('type', '').lower(),
+                jumpstart_name=config.get("name", name),
+                type=config.get("type", "").lower(),
                 workspace_id=installer.workspace_id,
                 entry_point=entry,
-                minutes_complete=config.get('minutes_to_complete_jumpstart'),
-                minutes_deploy=config.get('minutes_to_deploy'),
-                docs_uri=config.get('jumpstart_docs_uri'),
+                minutes_complete=config.get("minutes_to_complete_jumpstart"),
+                minutes_deploy=config.get("minutes_to_deploy"),
+                docs_uri=config.get("jumpstart_docs_uri"),
                 logs=log_buffer,
                 error_message=err,
                 extra_html=extra_html,
@@ -227,158 +250,177 @@ class jumpstart:
             if not unattended:
                 from IPython.display import HTML as _HTML
                 from IPython.display import display
+
                 HTML_cls = _HTML
-                live_handle = display(_HTML("<div>Starting install...</div>"), display_id=True)
+                live_handle = display(
+                    _HTML("<div>Starting install...</div>"), display_id=True
+                )
                 live_rendering = True
-                _update_live(status_label='installing')
+                _update_live(status_label="installing")
         except Exception:
             live_handle = None
             HTML_cls = None
             live_rendering = False
 
         # Setup log capture
-        current_status = {'label': 'installing', 'entry': None}  # Track current status
-        
+        current_status = {"label": "installing", "entry": None}  # Track current status
+
         def on_emit():
             # Only update if still in installing state (don't update_existing error/conflict/success)
-            if current_status['label'] == 'installing':
-                _update_live(status_label='installing', entry=None)
-        
+            if current_status["label"] == "installing":
+                _update_live(status_label="installing", entry=None)
+
         # Capture logs from fabric-cicd and fabric_jumpstart
         target_loggers = [
-            logging.getLogger('fabric_cicd'),
-            logging.getLogger('fabric_jumpstart'),
+            logging.getLogger("fabric_cicd"),
+            logging.getLogger("fabric_jumpstart"),
             logging.getLogger(__name__),
         ]
-        
-        with log_capture_context(log_buffer, target_loggers, on_emit=on_emit, debug=installer.debug_logs):
+
+        with log_capture_context(
+            log_buffer, target_loggers, on_emit=on_emit, debug=installer.debug_logs
+        ):
             try:
                 # Phase 1: Validate and prepare
                 installer.validate()
                 installer.prepare_workspace()
                 installer.initialize_workspace_manager()
-                
+
                 # Phase 2: Check for conflicts
-                planned_items_base, existing_items, conflicts, had_conflicts = installer.check_conflicts()
-                
+                planned_items_base, existing_items, conflicts, had_conflicts = (
+                    installer.check_conflicts()
+                )
+
                 # Phase 3: Resolve conflicts
                 resolved_prefix, remaining_conflicts = installer.resolve_conflicts(
-                    planned_items_base,
-                    existing_items,
-                    conflicts
+                    planned_items_base, existing_items, conflicts
                 )
-                
+
                 # If conflicts remain unresolved, render UI and fail
                 if remaining_conflicts:
                     conflict_html = ConflictUI.render_conflict_html(
-                        remaining_conflicts,
-                        instance_name,
-                        name,
-                        installer.workspace_id
+                        remaining_conflicts, instance_name, name, installer.workspace_id
                     )
-                    
+
                     if unattended:
-                        raise RuntimeError(f"Conflicting items detected: {', '.join(remaining_conflicts)}")
-                    
+                        raise RuntimeError(
+                            f"Conflicting items detected: {', '.join(remaining_conflicts)}"
+                        )
+
                     # Update live display with conflict UI
-                    current_status['label'] = 'conflict'  # Prevent on_emit from overwriting
+                    current_status["label"] = (
+                        "conflict"  # Prevent on_emit from overwriting
+                    )
                     _update_live(
-                        status_label='conflict',
-                        entry=config.get('entry_point'),
+                        status_label="conflict",
+                        entry=config.get("entry_point"),
                         err=None,
-                        extra_html=conflict_html
+                        extra_html=conflict_html,
                     )
                     conflict_already_rendered = True
-                    
+
                     # Raise error to mark cell as failed
-                    raise RuntimeError(f"Conflicting items detected: {', '.join(remaining_conflicts)}")
-                
+                    raise RuntimeError(
+                        f"Conflicting items detected: {', '.join(remaining_conflicts)}"
+                    )
+
                 # Phase 4: Apply prefix to files
                 installer.apply_prefix_to_files(resolved_prefix)
-                
+
                 # Phase 5: Deploy
-                logger.info(f"Deploying items from {installer.temp_workspace_path} to workspace '{installer.workspace_id}'")
+                logger.info(
+                    f"Deploying items from {installer.temp_workspace_path} to workspace '{installer.workspace_id}'"
+                )
                 target_ws = installer.deploy()
                 logger.info(f"Successfully installed '{name}'")
-                
+
+                # Phase 5.5: Upload files to lakehouse (if configured)
+                installer.upload_files(target_ws, resolved_prefix)
+
                 # Phase 6: Generate entry URL
                 entry_url = installer.generate_entry_url(target_ws, resolved_prefix)
-                
+
                 # Render success
-                current_status['label'] = 'success'  # Prevent on_emit from overwriting
+                current_status["label"] = "success"  # Prevent on_emit from overwriting
                 status_html = render_install_status_html(
-                    status='success',
-                    jumpstart_name=config.get('name', name),
-                    type=config.get('type', '').lower(),
+                    status="success",
+                    jumpstart_name=config.get("name", name),
+                    type=config.get("type", "").lower(),
                     workspace_id=installer.workspace_id,
                     entry_point=entry_url,
-                    minutes_complete=config.get('minutes_to_complete_jumpstart'),
-                    minutes_deploy=config.get('minutes_to_deploy'),
-                    docs_uri=config.get('jumpstart_docs_uri'),
+                    minutes_complete=config.get("minutes_to_complete_jumpstart"),
+                    minutes_deploy=config.get("minutes_to_deploy"),
+                    docs_uri=config.get("jumpstart_docs_uri"),
                     logs=log_buffer,
                 )
-                
-                _update_live(status_label='success', entry=entry_url)
-                
+
+                _update_live(status_label="success", entry=entry_url)
+
                 if unattended:
                     print(f"Installed '{name}' to workspace '{installer.workspace_id}'")
                     return None
-                
+
                 if live_rendering:
                     return None
-                
+
                 try:
                     from IPython.display import HTML
+
                     return HTML(status_html)
                 except Exception:
                     return status_html
-                    
+
             except Exception as e:
                 logger.exception(f"Failed to install jumpstart '{name}'")
                 error_text = str(e).strip() or e.__class__.__name__
-                
+
                 # Don't update_existing conflict UI if it's already been rendered
                 if conflict_already_rendered:
                     raise RuntimeError(error_text)
-                
+
                 try:
                     for line in traceback.format_exception(e):
                         clean_line = line.rstrip("\n")
                         if clean_line:
                             log_buffer.append({"level": "ERROR", "message": clean_line})
                     _update_live(
-                        status_label='error',
-                        entry=config.get('entry_point'),
-                        err=error_text
+                        status_label="error",
+                        entry=config.get("entry_point"),
+                        err=error_text,
                     )
                 except Exception:
                     pass
-                
+
                 if unattended:
                     print(f"Failed to install '{name}': {error_text}")
                     raise
-                
+
                 status_html = render_install_status_html(
-                    status='error',
-                    jumpstart_name=config.get('name', name),
-                    type=config.get('type', '').lower(),
+                    status="error",
+                    jumpstart_name=config.get("name", name),
+                    type=config.get("type", "").lower(),
                     workspace_id=installer.workspace_id,
-                    entry_point=config.get('entry_point'),
-                    minutes_complete=config.get('minutes_to_complete_jumpstart'),
-                    minutes_deploy=config.get('minutes_to_deploy'),
-                    docs_uri=config.get('jumpstart_docs_uri'),
+                    entry_point=config.get("entry_point"),
+                    minutes_complete=config.get("minutes_to_complete_jumpstart"),
+                    minutes_deploy=config.get("minutes_to_deploy"),
+                    docs_uri=config.get("jumpstart_docs_uri"),
                     logs=log_buffer,
                     error_message=error_text,
                 )
-                _update_live(status_label='error', entry=config.get('entry_point'), err=error_text)
-                
+                _update_live(
+                    status_label="error",
+                    entry=config.get("entry_point"),
+                    err=error_text,
+                )
+
                 if live_rendering:
                     raise RuntimeError(error_text)
-                
+
                 try:
                     from IPython.display import HTML, display
+
                     display(HTML(status_html))
                 except Exception:
                     pass
-                
+
                 raise RuntimeError(error_text)

--- a/src/fabric_jumpstart/fabric_jumpstart/installer.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/installer.py
@@ -13,6 +13,7 @@ from .utils import (
     _is_fabric_runtime,
     clone_files_to_temp_directory,
     clone_repository,
+    upload_files_to_lakehouse,
 )
 from .workspace_manager import WorkspaceManager
 
@@ -21,16 +22,12 @@ logger = logging.getLogger(__name__)
 
 class JumpstartInstaller:
     """Orchestrates the installation of a jumpstart to a Fabric workspace."""
-    
+
     def __init__(
-        self,
-        config: Dict,
-        workspace_id: Optional[str],
-        instance_name: str,
-        **options
+        self, config: Dict, workspace_id: Optional[str], instance_name: str, **options
     ):
         """Initialize the installer.
-        
+
         Args:
             config: Jumpstart configuration dictionary from registry
             workspace_id: Target workspace GUID
@@ -41,15 +38,17 @@ class JumpstartInstaller:
         self.workspace_id = workspace_id
         self.instance_name = instance_name
         self.options = options
-        
+
         # Extract common options
-        self.update_existing = bool(options.get('update_existing', False))
-        self.auto_prefix_on_conflict = bool(options.get('auto_prefix_on_conflict', False))
-        self.item_prefix = options.get('item_prefix')
-        self.unattended = options.get('unattended', False)
-        self.debug_logs = bool(options.get('debug', False))
-        self.repo_ref_override = options.get('repo_ref')
-        
+        self.update_existing = bool(options.get("update_existing", False))
+        self.auto_prefix_on_conflict = bool(
+            options.get("auto_prefix_on_conflict", False)
+        )
+        self.item_prefix = options.get("item_prefix")
+        self.unattended = options.get("unattended", False)
+        self.debug_logs = bool(options.get("debug", False))
+        self.repo_ref_override = options.get("repo_ref")
+
         # State tracking
         self.log_buffer: List[Dict] = []
         self.working_repo_path: Optional[Path] = None
@@ -57,57 +56,58 @@ class JumpstartInstaller:
         self.workspace_manager: Optional[WorkspaceManager] = None
         self.had_conflicts = False
         self.resolved_prefix: Optional[str] = None
-    
+
     def validate(self) -> str:
         """Validate configuration and resolve workspace ID.
-        
+
         Returns:
             Resolved workspace ID
-            
+
         Raises:
             ValueError: If workspace_id cannot be determined
         """
         if self.workspace_id is None and _is_fabric_runtime():
             import notebookutils  # type: ignore[import-untyped]
-            self.workspace_id = notebookutils.runtime.context['currentWorkspaceId']
-        
+
+            self.workspace_id = notebookutils.runtime.context["currentWorkspaceId"]
+
         if self.workspace_id is None:
             raise ValueError(
                 "workspace_id must be provided when not running inside a Fabric runtime"
             )
-        
+
         logger.info(
             f"Installing '{self.config.get('logical_id')}' to workspace '{self.workspace_id}'"
         )
         return self.workspace_id
-    
+
     def prepare_workspace(self) -> Path:
         """Clone/prepare the workspace directory.
-        
+
         Returns:
             Path to prepared workspace directory
         """
         from .utils import _set_item_prefix
-        
-        source_config = self.config['source']
-        workspace_path = source_config['workspace_path']
-        config_id = self.config.get('id')
+
+        source_config = self.config["source"]
+        workspace_path = source_config["workspace_path"]
+        config_id = self.config.get("id")
         if config_id is None:
             raise ValueError("Jumpstart config missing required 'id' field")
-        logical_id = self.config.get('logical_id', '')
+        logical_id = self.config.get("logical_id", "")
         system_prefix = _set_item_prefix(config_id, logical_id)
-        
-        if 'repo_url' in source_config:
+
+        if "repo_url" in source_config:
             # Remote jumpstart
-            repo_url = source_config['repo_url']
-            repo_ref = self.repo_ref_override or source_config['repo_ref']
+            repo_url = source_config["repo_url"]
+            repo_ref = self.repo_ref_override or source_config["repo_ref"]
             if self.repo_ref_override:
-                logger.info(f"Overriding registered repo_ref with '{self.repo_ref_override}'")
+                logger.info(
+                    f"Overriding registered repo_ref with '{self.repo_ref_override}'"
+                )
             logger.info(f"Cloning from {repo_url} (ref: {repo_ref})")
             self.working_repo_path = clone_repository(
-                repository_url=repo_url,
-                ref=repo_ref,
-                temp_dir_prefix=system_prefix
+                repository_url=repo_url, ref=repo_ref, temp_dir_prefix=system_prefix
             )
             logger.info(f"Repository cloned to {self.working_repo_path}")
         else:
@@ -116,210 +116,275 @@ class JumpstartInstaller:
             jumpstarts_dir = Path(__file__).parent / "jumpstarts"
             repo_path = jumpstarts_dir / logical_id
             self.working_repo_path = clone_files_to_temp_directory(
-                source_path=repo_path,
-                temp_dir_prefix=system_prefix
+                source_path=repo_path, temp_dir_prefix=system_prefix
             )
-            logger.info(f"Cloned local repo_path {repo_path} to temp {self.working_repo_path}")
-        
-        self.temp_workspace_path = self.working_repo_path / workspace_path.lstrip('/\\')
+            logger.info(
+                f"Cloned local repo_path {repo_path} to temp {self.working_repo_path}"
+            )
+
+        self.temp_workspace_path = self.working_repo_path / workspace_path.lstrip("/\\")
         logger.info(f"Workspace path {self.temp_workspace_path}")
         return self.temp_workspace_path
-    
+
     def initialize_workspace_manager(self) -> WorkspaceManager:
         """Initialize the workspace manager.
-        
+
         Returns:
             Configured WorkspaceManager instance
-            
+
         Raises:
             RuntimeError: If workspace_id or temp_workspace_path is not set
         """
         if self.workspace_id is None:
-            raise RuntimeError("workspace_id must be set before initializing workspace manager")
+            raise RuntimeError(
+                "workspace_id must be set before initializing workspace manager"
+            )
         if self.temp_workspace_path is None:
-            raise RuntimeError("temp_workspace_path must be set before initializing workspace manager")
-            
-        items_in_scope = self.config.get('items_in_scope', [])
+            raise RuntimeError(
+                "temp_workspace_path must be set before initializing workspace manager"
+            )
+
+        items_in_scope = self.config.get("items_in_scope", [])
         self.workspace_manager = WorkspaceManager(
             workspace_id=self.workspace_id,
             workspace_path=self.temp_workspace_path,
-            items_in_scope=items_in_scope
+            items_in_scope=items_in_scope,
         )
         return self.workspace_manager
-    
-    def check_conflicts(
-        self
-    ) -> tuple[List[str], List[str], List[str], bool]:
+
+    def check_conflicts(self) -> tuple[List[str], List[str], List[str], bool]:
         """Check for item name conflicts.
-        
+
         Returns:
             Tuple of (planned_items, existing_items, conflicts, had_conflicts)
-            
+
         Raises:
             RuntimeError: If workspace_manager is not initialized
         """
         if self.workspace_manager is None:
-            raise RuntimeError("workspace_manager must be initialized before checking conflicts")
-            
+            raise RuntimeError(
+                "workspace_manager must be initialized before checking conflicts"
+            )
+
         existing_items = self.workspace_manager.get_existing_items()
         planned_items_base = self.workspace_manager.collect_planned_items()
         planned_items = self.workspace_manager.apply_prefix_to_names(
-            planned_items_base,
-            self.item_prefix
+            planned_items_base, self.item_prefix
         )
-        
+
         detector = ConflictDetector(self.workspace_manager)
-        conflicts, had_conflicts = detector.check_for_conflicts(planned_items, existing_items)
-        
+        conflicts, had_conflicts = detector.check_for_conflicts(
+            planned_items, existing_items
+        )
+
         return planned_items_base, existing_items, conflicts, had_conflicts
-    
+
     def resolve_conflicts(
         self,
         planned_items_base: List[str],
         existing_items: List[str],
-        conflicts: List[str]
+        conflicts: List[str],
     ) -> tuple[Optional[str], List[str]]:
         """Resolve conflicts using configured strategy.
-        
+
         Args:
             planned_items_base: Base planned items without prefix
             existing_items: Existing items in workspace
             conflicts: Detected conflicts
-            
+
         Returns:
             Tuple of (resolved_prefix, remaining_conflicts)
-            
+
         Raises:
             RuntimeError: If conflicts remain and no resolution strategy is enabled
         """
         if not conflicts:
             return self.item_prefix, []
-        
+
         self.had_conflicts = True
         logger.info(f"Conflicting items detected: {conflicts}")
-        
+
         if self.auto_prefix_on_conflict:
             if self.workspace_manager is None:
                 raise RuntimeError("workspace_manager must be initialized")
-            config_id = self.config.get('id')
+            config_id = self.config.get("id")
             if config_id is None:
                 raise ValueError("Jumpstart config missing required 'id' field")
-                
+
             resolver = ConflictResolver(
-                self.workspace_manager,
-                config_id,
-                self.config.get('logical_id', '')
+                self.workspace_manager, config_id, self.config.get("logical_id", "")
             )
-            prefixed_items, remaining_conflicts, prefix_used = resolver.resolve_with_prefix(
-                planned_items_base,
-                existing_items
+            prefixed_items, remaining_conflicts, prefix_used = (
+                resolver.resolve_with_prefix(planned_items_base, existing_items)
             )
-            
+
             if not remaining_conflicts:
                 logger.info(f"Conflicts resolved via auto-prefix '{prefix_used}'")
                 self.resolved_prefix = f"{prefix_used}{self.item_prefix or ''}"
                 return self.resolved_prefix, []
             else:
                 conflicts = remaining_conflicts
-        
+
         if self.update_existing:
-            logger.info(f"Conflicts resolved via update_existing flag; proceeding: {conflicts}")
+            logger.info(
+                f"Conflicts resolved via update_existing flag; proceeding: {conflicts}"
+            )
             return self.item_prefix, []
-        
+
         # Conflicts remain and no resolution strategy
         return self.item_prefix, conflicts
-    
+
     def apply_prefix_to_files(self, prefix: Optional[str]) -> List[tuple]:
         """Apply item prefix to workspace files.
-        
+
         Args:
             prefix: Prefix to apply
-            
+
         Returns:
             List of (old_name, new_name) mappings
-            
+
         Raises:
             RuntimeError: If temp_workspace_path is not set
         """
         if self.temp_workspace_path is None:
             raise RuntimeError("temp_workspace_path must be set before applying prefix")
-            
-        entry_point = self.config.get('entry_point')
+
+        entry_point = self.config.get("entry_point")
         base_names = []
-        if entry_point and isinstance(entry_point, str) and '.' in entry_point:
-            base_names.append(entry_point.split('.')[0])
-        
+        if entry_point and isinstance(entry_point, str) and "." in entry_point:
+            base_names.append(entry_point.split(".")[0])
+
         logger.info(
             f"Applying item prefix '{prefix}' to workspace path {self.temp_workspace_path} "
             f"with base_names={base_names}"
         )
-        
-        prefix_mappings = _apply_item_prefix(self.temp_workspace_path, prefix, base_names=base_names)
-        
+
+        prefix_mappings = _apply_item_prefix(
+            self.temp_workspace_path, prefix, base_names=base_names
+        )
+
         if prefix:
             logger.info(f"Item prefix mappings applied: {prefix_mappings}")
         if self.auto_prefix_on_conflict and self.had_conflicts and prefix:
             logger.info(f"Auto-prefix applied with mappings: {prefix_mappings}")
-        
+
         return prefix_mappings
-    
+
     def deploy(self) -> FabricWorkspace:
         """Deploy items to workspace.
-        
+
         Returns:
             FabricWorkspace instance after deployment
-            
+
         Raises:
             RuntimeError: If workspace_manager is not initialized
         """
         if self.workspace_manager is None:
             raise RuntimeError("workspace_manager must be initialized before deploying")
-            
-        feature_flags = self.options.get('feature_flags', [])
+
+        feature_flags = self.options.get("feature_flags", [])
         return self.workspace_manager.deploy_items(feature_flags)
-    
-    def generate_entry_url(self, target_ws: FabricWorkspace, prefix: Optional[str]) -> Optional[str]:
+
+    def upload_files(self, target_ws: FabricWorkspace, prefix: Optional[str]) -> int:
+        """Upload files from cloned repo to a deployed Lakehouse.
+
+        Reads files_source_path, files_destination_lakehouse, and
+        files_destination_path from the source config.  Returns 0 when
+        file upload is not configured.
+
+        Args:
+            target_ws: Deployed FabricWorkspace instance
+            prefix: Applied item prefix (or None)
+
+        Returns:
+            Number of files uploaded
+        """
+        source_config = self.config.get("source", {})
+        files_source = source_config.get("files_source_path")
+        dest_lakehouse = source_config.get("files_destination_lakehouse")
+        if not files_source or not dest_lakehouse:
+            return 0
+
+        dest_path = source_config.get("files_destination_path", "")
+
+        # Build local source from cloned repo
+        if self.working_repo_path is None:
+            raise RuntimeError("working_repo_path must be set before uploading files")
+        local_source = self.working_repo_path / files_source.lstrip("/\\")
+
+        # Apply prefix to lakehouse name if applicable
+        lakehouse_name = dest_lakehouse
+        if prefix:
+            lakehouse_name = f"{prefix}{dest_lakehouse}"
+
+        # Resolve lakehouse ID from the deployed workspace
+        from fabric_cicd._parameter._utils import _extract_item_attribute
+
+        lakehouse_id = _extract_item_attribute(
+            target_ws,
+            f"$items.Lakehouse.{lakehouse_name}.$id",
+            False,
+        )
+
+        logger.info(
+            "Uploading files from '%s' to lakehouse '%s' (path: '%s')",
+            local_source,
+            lakehouse_name,
+            dest_path or "/",
+        )
+
+        count = upload_files_to_lakehouse(
+            workspace_id=target_ws.workspace_id,
+            lakehouse_id=lakehouse_id,
+            source_path=local_source,
+            destination_path=dest_path,
+        )
+
+        logger.info("Uploaded %d file(s) to lakehouse '%s'", count, lakehouse_name)
+        return count
+
+    def generate_entry_url(
+        self, target_ws: FabricWorkspace, prefix: Optional[str]
+    ) -> Optional[str]:
         """Generate entry point URL for deployed jumpstart.
-        
+
         Args:
             target_ws: Deployed FabricWorkspace
             prefix: Applied prefix
-            
+
         Returns:
             Entry point URL or None
         """
-        entry_point = self.config.get('entry_point')
+        entry_point = self.config.get("entry_point")
         if not entry_point:
             return None
-        
+
         # Apply prefix to entry point if needed
         prefixed_entry_point = entry_point
-        if prefix and not entry_point.startswith(('http://', 'https://')):
+        if prefix and not entry_point.startswith(("http://", "https://")):
             prefixed_entry_point = f"{prefix}{entry_point}"
-        
+
         # If already a URL, return as-is
-        if prefixed_entry_point.startswith(('http://', 'https://')):
+        if prefixed_entry_point.startswith(("http://", "https://")):
             return prefixed_entry_point
-        
+
         # Generate Fabric item URL
         from fabric_cicd._parameter._utils import _extract_item_attribute
-        
-        parts = prefixed_entry_point.split('.')
+
+        parts = prefixed_entry_point.split(".")
         if len(parts) >= 2:
             item_name, item_type = parts[0], parts[1]
             item_id = _extract_item_attribute(
-                target_ws,
-                f"$items.{item_type}.{item_name}.$id",
-                False
+                target_ws, f"$items.{item_type}.{item_name}.$id", False
             )
-            
+
             routing_path = ITEM_URL_ROUTING_PATH_MAP.get(item_type)
             if not routing_path:
                 raise ValueError(f"Unsupported entry point item type: {item_type}")
-            
+
             return (
                 f"https://app.powerbi.com/groups/{target_ws.workspace_id}"
                 f"/{routing_path}/{item_id}?experience=fabric-developer"
             )
-        
+
         return None

--- a/src/fabric_jumpstart/fabric_jumpstart/utils.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/utils.py
@@ -50,6 +50,7 @@ def resolve_token_credential():
 
     module_path, class_name = qualified.rsplit(".", 1)
     import importlib
+
     module = importlib.import_module(module_path)
     cls = getattr(module, class_name)
     credential = cls()
@@ -60,14 +61,19 @@ def resolve_token_credential():
 def _is_fabric_runtime() -> bool:
     """Checks if the execution runtime is Fabric."""
     try:
-        notebookutils = __import__('notebookutils')
-        if notebookutils and hasattr(notebookutils, "runtime") and hasattr(notebookutils.runtime, "context"):
+        notebookutils = __import__("notebookutils")
+        if (
+            notebookutils
+            and hasattr(notebookutils, "runtime")
+            and hasattr(notebookutils.runtime, "context")
+        ):
             context = notebookutils.runtime.context
             if "productType" in context:
                 return context["productType"].lower() == "fabric"
         return False
     except Exception:
         return False
+
 
 def download_file(url: str, dest: str):
     with requests.get(url, stream=True) as r:
@@ -76,30 +82,33 @@ def download_file(url: str, dest: str):
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
 
+
 def set_workspace_in_yml(yml_path: str, workspace_name: str):
     import yaml
-    with open(yml_path, 'r') as f:
+
+    with open(yml_path, "r") as f:
         data = yaml.safe_load(f)
     # Modify workspace for core section
-    data['core']['workspace'] = workspace_name
-    with open(yml_path, 'w') as f:
+    data["core"]["workspace"] = workspace_name
+    with open(yml_path, "w") as f:
         yaml.safe_dump(data, f, sort_keys=False)
+
 
 def create_working_directory(temp_dir_prefix: str = "fabric-jumpstart-") -> Path:
     dest_dir = tempfile.mkdtemp(prefix=temp_dir_prefix)
     return Path(dest_dir)
 
+
 def clone_files_to_temp_directory(
-    source_path: Path,
-    temp_dir_prefix: str = "fabric-jumpstart-"
+    source_path: Path, temp_dir_prefix: str = "fabric-jumpstart-"
 ):
     """
     Clone files from source_path to a temporary directory, preserving structure.
-    
+
     Args:
         source_path: Path to source directory
         temp_dir_prefix: Prefix for the temporary directory name
-    
+
     Returns:
         Path to the temporary directory
     """
@@ -118,12 +127,16 @@ def clone_files_to_temp_directory(
 
 def _set_item_prefix(id: int, logical_id: str) -> str:
     """Generate item prefix for Item naming."""
-    logical_words = logical_id.split('-')
-    short_logical_id = ''.join(word[0] for word in logical_words if word)
+    logical_words = logical_id.split("-")
+    short_logical_id = "".join(word[0] for word in logical_words if word)
     return f"js{id}_{short_logical_id}__"
 
 
-def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_names: Optional[list[str]] = None):
+def _apply_item_prefix(
+    workspace_path: Path,
+    item_prefix: Optional[str],
+    base_names: Optional[list[str]] = None,
+):
     """Rename item folders and references with the provided prefix.
 
     - Renames item directories shaped like "Name.Type" to "{prefix}Name.Type".
@@ -135,7 +148,11 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
         return []
 
     if not workspace_path.exists():
-        logger.info("Item prefix '%s' skipped; workspace path does not exist: %s", item_prefix, workspace_path)
+        logger.info(
+            "Item prefix '%s' skipped; workspace path does not exist: %s",
+            item_prefix,
+            workspace_path,
+        )
         return []
 
     mappings = []  # (old_base, new_base)
@@ -143,8 +160,7 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
 
     # Collect candidate item directories anywhere under workspace_path
     candidate_dirs = [
-        p for p in workspace_path.rglob('*')
-        if p.is_dir() and '.' in p.name
+        p for p in workspace_path.rglob("*") if p.is_dir() and "." in p.name
     ]
 
     # Rename deeper paths first to avoid conflicts if nesting exists
@@ -152,7 +168,7 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
         # If already prefixed, skip to avoid double-prefixing
         if item_prefix and entry.name.startswith(item_prefix):
             continue
-        old_base, _, suffix = entry.name.partition('.')
+        old_base, _, suffix = entry.name.partition(".")
         if not old_base or not suffix:
             continue
 
@@ -161,7 +177,9 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
         new_path = entry.with_name(new_name)
         candidates.append((old_base, entry))
         if new_path.exists():
-            logger.info("Prefixed item path already exists, skipping rename: %s", new_path)
+            logger.info(
+                "Prefixed item path already exists, skipping rename: %s", new_path
+            )
             mappings.append((old_base, new_base))
             continue
         entry.rename(new_path)
@@ -183,14 +201,14 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
         return []
 
     modified_files = []
-    for file_path in workspace_path.rglob('*'):
+    for file_path in workspace_path.rglob("*"):
         if not file_path.is_file():
             continue
         try:
-            content = file_path.read_text(encoding='utf-8')
+            content = file_path.read_text(encoding="utf-8")
         except Exception:
             try:
-                content = file_path.read_text(encoding='utf-8', errors='ignore')
+                content = file_path.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue  # skip binaries or unreadable files
 
@@ -199,12 +217,13 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
             # Use word boundary matching to avoid replacing partial matches
             # and avoid replacing text that's already prefixed
             import re
+
             # Negative lookbehind to ensure we don't replace already-prefixed occurrences
-            pattern = rf'(?<!{re.escape(item_prefix)})\b{re.escape(old_base)}\b'
+            pattern = rf"(?<!{re.escape(item_prefix)})\b{re.escape(old_base)}\b"
             new_content = re.sub(pattern, new_base, new_content)
 
         if new_content != content:
-            file_path.write_text(new_content, encoding='utf-8')
+            file_path.write_text(new_content, encoding="utf-8")
             modified_files.append(file_path)
 
     logger.info(
@@ -217,40 +236,156 @@ def _apply_item_prefix(workspace_path: Path, item_prefix: Optional[str], base_na
     )
     return mappings
 
+
+def upload_files_to_lakehouse(
+    workspace_id: str,
+    lakehouse_id: str,
+    source_path: Path,
+    destination_path: str = "",
+) -> int:
+    """Upload a file or folder to a Lakehouse Files area via the OneLake DFS API.
+
+    Args:
+        workspace_id: Target workspace GUID
+        lakehouse_id: Target lakehouse item GUID
+        source_path: Local file or directory to upload
+        destination_path: Destination path under Files/ (empty string for root)
+
+    Returns:
+        Number of files uploaded
+
+    Raises:
+        FileNotFoundError: If source_path does not exist
+        RuntimeError: If an upload request fails
+    """
+    source = Path(source_path)
+    if not source.exists():
+        raise FileNotFoundError(f"Source path does not exist: {source}")
+
+    # Resolve bearer token
+    if _is_fabric_runtime():
+        import notebookutils  # type: ignore[import-untyped]
+
+        token = notebookutils.credentials.getToken("storage")
+    else:
+        credential = resolve_token_credential()
+        if credential is None:
+            from azure.identity import DefaultAzureCredential
+
+            credential = DefaultAzureCredential()
+        token_obj = credential.get_token("https://storage.azure.com/.default")
+        token = token_obj.token
+
+    headers = {"Authorization": f"Bearer {token}"}
+    base_url = (
+        f"https://onelake.dfs.fabric.microsoft.com/{workspace_id}/{lakehouse_id}/Files"
+    )
+    dest_prefix = destination_path.strip("/")
+
+    files_to_upload: list[tuple[Path, str]] = []
+    if source.is_file():
+        rel = source.name
+        if dest_prefix:
+            rel = f"{dest_prefix}/{rel}"
+        files_to_upload.append((source, rel))
+    else:
+        for file_path in source.rglob("*"):
+            if not file_path.is_file():
+                continue
+            rel = file_path.relative_to(source).as_posix()
+            if dest_prefix:
+                rel = f"{dest_prefix}/{rel}"
+            files_to_upload.append((file_path, rel))
+
+    uploaded = 0
+    for local_file, rel_path in files_to_upload:
+        file_url = f"{base_url}/{rel_path}"
+        file_size = local_file.stat().st_size
+
+        # Step 1: Create
+        resp = requests.put(
+            file_url,
+            headers=headers,
+            params={"resource": "file"},
+        )
+        if resp.status_code not in (201, 409):
+            raise RuntimeError(
+                f"Failed to create file '{rel_path}': {resp.status_code} {resp.text}"
+            )
+
+        # Step 2: Append
+        with open(local_file, "rb") as f:
+            data = f.read()
+        resp = requests.patch(
+            file_url,
+            headers={**headers, "Content-Type": "application/octet-stream"},
+            params={"action": "append", "position": "0"},
+            data=data,
+        )
+        if resp.status_code != 202:
+            raise RuntimeError(
+                f"Failed to append data for '{rel_path}': {resp.status_code} {resp.text}"
+            )
+
+        # Step 3: Flush
+        resp = requests.patch(
+            file_url,
+            headers=headers,
+            params={"action": "flush", "position": str(file_size)},
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Failed to flush file '{rel_path}': {resp.status_code} {resp.text}"
+            )
+
+        logger.info("Uploaded %s", rel_path)
+        uploaded += 1
+
+    return uploaded
+
+
 def clone_repository(
     repository_url: str,
     ref: Optional[str] = None,
-    temp_dir_prefix: str = "fabric-jumpstart-"
+    temp_dir_prefix: str = "fabric-jumpstart-",
 ) -> Path:
     """
     Clone a git repository to a destination directory.
-    
+
     Args:
         repository_url: URL of the git repository
         ref: Git reference (branch, tag, or commit hash). Defaults to 'main'
         temp_dir_prefix: Prefix for the temporary directory name
-    
+
     Returns:
         Path to cloned repository
-    
+
     Raises:
         RuntimeError: If git clone fails
     """
     git_ref = ref or "main"
-    
+
     dest_dir = create_working_directory(temp_dir_prefix)
-    
+
     try:
         # Clone with specific reference using --branch
         # Git's --branch works with branches, tags, and commit hashes
         subprocess.run(
-            ["git", "clone", "--branch", git_ref, "--single-branch", repository_url, dest_dir],
+            [
+                "git",
+                "clone",
+                "--branch",
+                git_ref,
+                "--single-branch",
+                repository_url,
+                dest_dir,
+            ],
             check=True,
             capture_output=True,
-            text=True
+            text=True,
         )
         return dest_dir
-    
+
     except subprocess.CalledProcessError as e:
         # Clean up on failure
         if Path(dest_dir).exists():

--- a/src/fabric_jumpstart/tests/schemas.py
+++ b/src/fabric_jumpstart/tests/schemas.py
@@ -17,22 +17,39 @@ from fabric_jumpstart.constants import (
 
 class JumpstartSource(BaseModel):
     """Source configuration for a jumpstart."""
+
     workspace_path: str
     preview_image_path: str
     repo_url: Optional[str] = None
     repo_ref: Optional[str] = None
+    files_source_path: Optional[str] = None
+    files_destination_lakehouse: Optional[str] = None
+    files_destination_path: Optional[str] = None
 
     @model_validator(mode="after")
     def validate_repo_fields(self):
         if self.repo_url:
             ref = (self.repo_ref or "").strip()
             if not ref:
-                raise ValueError("repo_ref, a tag of the repository, must be provided when repo_url is set")
+                raise ValueError(
+                    "repo_ref, a tag of the repository, must be provided when repo_url is set"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_files_upload_fields(self):
+        has_source = bool((self.files_source_path or "").strip())
+        has_lakehouse = bool((self.files_destination_lakehouse or "").strip())
+        if has_source != has_lakehouse:
+            raise ValueError(
+                "files_source_path and files_destination_lakehouse must both be provided or both be omitted"
+            )
         return self
 
 
 class Jumpstart(BaseModel):
     """Schema for a jumpstart entry."""
+
     model_config = ConfigDict(extra="forbid")
 
     id: int
@@ -40,7 +57,9 @@ class Jumpstart(BaseModel):
     name: str
     description: str
     date_added: str
-    include_in_listing: Optional[bool] = True # excluded from listing if False or not set
+    include_in_listing: Optional[bool] = (
+        True  # excluded from listing if False or not set
+    )
     workload_tags: List[str]
     scenario_tags: List[str]
     type: Optional[str] = "Accelerator"
@@ -91,7 +110,7 @@ class Jumpstart(BaseModel):
         except Exception:
             raise ValueError("date_added must be a valid date in MM/DD/YYYY format")
         return value
-    
+
     @field_validator("owner_email")
     @classmethod
     def validate_owner_email(cls, value: str):
@@ -151,7 +170,7 @@ class Jumpstart(BaseModel):
                 f"Unknown jumpstart_type: {value}. Allowed values: {allowed_display}."
             )
         return value
-    
+
     @field_validator("items_in_scope")
     @classmethod
     def validate_items_in_scope(cls, value: List[str]):
@@ -165,7 +184,9 @@ class Jumpstart(BaseModel):
                 )
         return value
 
-    @field_validator("minutes_to_complete_jumpstart", "minutes_to_deploy", mode="before")
+    @field_validator(
+        "minutes_to_complete_jumpstart", "minutes_to_deploy", mode="before"
+    )
     @classmethod
     def coerce_minutes(cls, value):
         if value in (None, ""):

--- a/src/fabric_jumpstart/tests/test_upload.py
+++ b/src/fabric_jumpstart/tests/test_upload.py
@@ -1,0 +1,361 @@
+"""Tests for lakehouse file upload feature."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from fabric_jumpstart.installer import JumpstartInstaller
+from fabric_jumpstart.utils import upload_files_to_lakehouse
+
+from .schemas import JumpstartSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**source_overrides):
+    """Return a minimal jumpstart config dict with optional source overrides."""
+    source = {
+        "repo_url": "https://github.com/example/repo.git",
+        "repo_ref": "v1.0.0",
+        "workspace_path": "demo/",
+        "preview_image_path": "demo/preview.png",
+    }
+    source.update(source_overrides)
+    return {
+        "id": 1,
+        "logical_id": "test-jumpstart",
+        "source": source,
+    }
+
+
+def _mock_response(status_code, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Group 1: upload_files_to_lakehouse (utils.py)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadFilesToLakehouse:
+    """Tests for the upload_files_to_lakehouse utility function."""
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.resolve_token_credential")
+    @patch("fabric_jumpstart.utils.requests")
+    def test_upload_single_file(self, mock_requests, mock_cred, _mock_rt, tmp_path):
+        """A single file triggers exactly one create + append + flush cycle."""
+        single_file = tmp_path / "data.csv"
+        single_file.write_text("a,b,c")
+
+        cred = MagicMock()
+        cred.get_token.return_value = MagicMock(token="tok")
+        mock_cred.return_value = cred
+
+        mock_requests.put.return_value = _mock_response(201)
+        mock_requests.patch.side_effect = [
+            _mock_response(202),  # append
+            _mock_response(200),  # flush
+        ]
+
+        count = upload_files_to_lakehouse("ws-1", "lh-1", single_file)
+
+        assert count == 1
+        mock_requests.put.assert_called_once()
+        assert mock_requests.patch.call_count == 2
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.resolve_token_credential")
+    @patch("fabric_jumpstart.utils.requests")
+    def test_upload_folder_recursively(
+        self, mock_requests, mock_cred, _mock_rt, tmp_path
+    ):
+        """A folder with nested files uploads all files recursively."""
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "a.csv").write_text("1")
+        (tmp_path / "sub" / "b.csv").write_text("2")
+
+        cred = MagicMock()
+        cred.get_token.return_value = MagicMock(token="tok")
+        mock_cred.return_value = cred
+
+        mock_requests.put.return_value = _mock_response(201)
+        mock_requests.patch.return_value = _mock_response(202)
+        # flush needs status 200
+        mock_requests.patch.side_effect = None
+        # We need alternating 202/200 for each file (append then flush)
+        mock_requests.patch.side_effect = [
+            _mock_response(202),
+            _mock_response(200),  # file 1
+            _mock_response(202),
+            _mock_response(200),  # file 2
+        ]
+
+        count = upload_files_to_lakehouse("ws-1", "lh-1", tmp_path)
+
+        assert count == 2
+        assert mock_requests.put.call_count == 2
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.resolve_token_credential")
+    @patch("fabric_jumpstart.utils.requests")
+    def test_upload_with_destination_path(
+        self, mock_requests, mock_cred, _mock_rt, tmp_path
+    ):
+        """destination_path is included in the upload URL."""
+        f = tmp_path / "file.json"
+        f.write_text("{}")
+
+        cred = MagicMock()
+        cred.get_token.return_value = MagicMock(token="tok")
+        mock_cred.return_value = cred
+
+        mock_requests.put.return_value = _mock_response(201)
+        mock_requests.patch.side_effect = [_mock_response(202), _mock_response(200)]
+
+        upload_files_to_lakehouse("ws-1", "lh-1", f, destination_path="ref-data")
+
+        put_url = mock_requests.put.call_args[0][0]
+        assert "/Files/ref-data/file.json" in put_url
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.resolve_token_credential")
+    @patch("fabric_jumpstart.utils.requests")
+    def test_upload_empty_destination_path(
+        self, mock_requests, mock_cred, _mock_rt, tmp_path
+    ):
+        """Empty destination_path uploads to the root of Files/."""
+        f = tmp_path / "file.json"
+        f.write_text("{}")
+
+        cred = MagicMock()
+        cred.get_token.return_value = MagicMock(token="tok")
+        mock_cred.return_value = cred
+
+        mock_requests.put.return_value = _mock_response(201)
+        mock_requests.patch.side_effect = [_mock_response(202), _mock_response(200)]
+
+        upload_files_to_lakehouse("ws-1", "lh-1", f, destination_path="")
+
+        put_url = mock_requests.put.call_args[0][0]
+        assert put_url.endswith("/Files/file.json")
+
+    def test_upload_source_not_found_raises(self, tmp_path):
+        """Non-existent source_path raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            upload_files_to_lakehouse("ws-1", "lh-1", tmp_path / "nope")
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.resolve_token_credential")
+    @patch("fabric_jumpstart.utils.requests")
+    def test_upload_create_failure_raises(
+        self, mock_requests, mock_cred, _mock_rt, tmp_path
+    ):
+        """A non-201/409 status on file create raises RuntimeError."""
+        f = tmp_path / "file.csv"
+        f.write_text("x")
+
+        cred = MagicMock()
+        cred.get_token.return_value = MagicMock(token="tok")
+        mock_cred.return_value = cred
+
+        mock_requests.put.return_value = _mock_response(403, "Forbidden")
+
+        with pytest.raises(RuntimeError, match="Failed to create file"):
+            upload_files_to_lakehouse("ws-1", "lh-1", f)
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.resolve_token_credential")
+    @patch("fabric_jumpstart.utils.requests")
+    def test_upload_empty_folder_returns_zero(
+        self, mock_requests, mock_cred, _mock_rt, tmp_path
+    ):
+        """An empty directory results in 0 uploads."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        cred = MagicMock()
+        cred.get_token.return_value = MagicMock(token="tok")
+        mock_cred.return_value = cred
+
+        count = upload_files_to_lakehouse("ws-1", "lh-1", empty_dir)
+
+        assert count == 0
+        mock_requests.put.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Group 2: JumpstartInstaller.upload_files (installer.py)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallerUploadFiles:
+    """Tests for JumpstartInstaller.upload_files orchestration."""
+
+    def test_returns_zero_when_not_configured(self):
+        """Config without files_source_path returns 0 immediately."""
+        installer = JumpstartInstaller(
+            _make_config(), workspace_id="ws-1", instance_name="js"
+        )
+        result = installer.upload_files(MagicMock(), prefix=None)
+        assert result == 0
+
+    @patch("fabric_jumpstart.installer.upload_files_to_lakehouse", return_value=3)
+    @patch(
+        "fabric_cicd._parameter._utils._extract_item_attribute",
+        return_value="lh-id-123",
+    )
+    def test_applies_prefix_to_lakehouse_name(
+        self, mock_extract, mock_upload, tmp_path
+    ):
+        """Prefix is prepended to the lakehouse name when resolving the ID."""
+        config = _make_config(
+            files_source_path="data/",
+            files_destination_lakehouse="MyLH",
+            files_destination_path="output",
+        )
+        installer = JumpstartInstaller(config, workspace_id="ws-1", instance_name="js")
+        installer.working_repo_path = tmp_path
+        (tmp_path / "data").mkdir()
+
+        target_ws = MagicMock()
+        installer.upload_files(target_ws, prefix="js1_bl__")
+
+        mock_extract.assert_called_once()
+        attr_path = mock_extract.call_args[0][1]
+        assert attr_path == "$items.Lakehouse.js1_bl__MyLH.$id"
+
+    @patch("fabric_jumpstart.installer.upload_files_to_lakehouse", return_value=1)
+    @patch(
+        "fabric_cicd._parameter._utils._extract_item_attribute",
+        return_value="lh-id-456",
+    )
+    def test_no_prefix(self, mock_extract, mock_upload, tmp_path):
+        """Without prefix, the lakehouse name is used as-is."""
+        config = _make_config(
+            files_source_path="data/",
+            files_destination_lakehouse="MyLH",
+        )
+        installer = JumpstartInstaller(config, workspace_id="ws-1", instance_name="js")
+        installer.working_repo_path = tmp_path
+        (tmp_path / "data").mkdir()
+
+        target_ws = MagicMock()
+        installer.upload_files(target_ws, prefix=None)
+
+        attr_path = mock_extract.call_args[0][1]
+        assert attr_path == "$items.Lakehouse.MyLH.$id"
+
+    def test_raises_without_working_repo_path(self):
+        """Raises RuntimeError if working_repo_path is not set."""
+        config = _make_config(
+            files_source_path="data/",
+            files_destination_lakehouse="MyLH",
+        )
+        installer = JumpstartInstaller(config, workspace_id="ws-1", instance_name="js")
+        # working_repo_path is None by default
+
+        with pytest.raises(RuntimeError, match="working_repo_path"):
+            installer.upload_files(MagicMock(), prefix=None)
+
+    @patch("fabric_jumpstart.installer.upload_files_to_lakehouse", return_value=2)
+    @patch(
+        "fabric_cicd._parameter._utils._extract_item_attribute", return_value="lh-id"
+    )
+    def test_passes_destination_path(self, mock_extract, mock_upload, tmp_path):
+        """files_destination_path from config is forwarded to the upload utility."""
+        config = _make_config(
+            files_source_path="data/",
+            files_destination_lakehouse="MyLH",
+            files_destination_path="ref-data",
+        )
+        installer = JumpstartInstaller(config, workspace_id="ws-1", instance_name="js")
+        installer.working_repo_path = tmp_path
+        (tmp_path / "data").mkdir()
+
+        installer.upload_files(MagicMock(), prefix=None)
+
+        _, kwargs = mock_upload.call_args
+        assert kwargs["destination_path"] == "ref-data"
+
+    @patch("fabric_jumpstart.installer.upload_files_to_lakehouse", return_value=1)
+    @patch(
+        "fabric_cicd._parameter._utils._extract_item_attribute", return_value="lh-id"
+    )
+    def test_default_destination_path(self, mock_extract, mock_upload, tmp_path):
+        """When files_destination_path is omitted, defaults to empty string."""
+        config = _make_config(
+            files_source_path="data/",
+            files_destination_lakehouse="MyLH",
+        )
+        installer = JumpstartInstaller(config, workspace_id="ws-1", instance_name="js")
+        installer.working_repo_path = tmp_path
+        (tmp_path / "data").mkdir()
+
+        installer.upload_files(MagicMock(), prefix=None)
+
+        _, kwargs = mock_upload.call_args
+        assert kwargs["destination_path"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Group 3: Schema validation (schemas.py)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceFilesSchemaValidation:
+    """Tests for files_source_path / files_destination_lakehouse schema rules."""
+
+    def test_both_files_fields_present_is_valid(self):
+        src = JumpstartSource(
+            workspace_path="demo/",
+            preview_image_path="demo/preview.png",
+            files_source_path="data/",
+            files_destination_lakehouse="MyLH",
+        )
+        assert src.files_source_path == "data/"
+        assert src.files_destination_lakehouse == "MyLH"
+
+    def test_both_files_fields_omitted_is_valid(self):
+        src = JumpstartSource(
+            workspace_path="demo/",
+            preview_image_path="demo/preview.png",
+        )
+        assert src.files_source_path is None
+        assert src.files_destination_lakehouse is None
+
+    def test_only_source_path_raises(self):
+        with pytest.raises(
+            ValidationError, match="files_source_path and files_destination_lakehouse"
+        ):
+            JumpstartSource(
+                workspace_path="demo/",
+                preview_image_path="demo/preview.png",
+                files_source_path="data/",
+            )
+
+    def test_only_destination_lakehouse_raises(self):
+        with pytest.raises(
+            ValidationError, match="files_source_path and files_destination_lakehouse"
+        ):
+            JumpstartSource(
+                workspace_path="demo/",
+                preview_image_path="demo/preview.png",
+                files_destination_lakehouse="MyLH",
+            )
+
+    def test_files_destination_path_alone_is_valid(self):
+        """files_destination_path by itself is harmless (no-op without the other two)."""
+        src = JumpstartSource(
+            workspace_path="demo/",
+            preview_image_path="demo/preview.png",
+            files_destination_path="output",
+        )
+        assert src.files_destination_path == "output"


### PR DESCRIPTION
- Added `upload_files_to_lakehouse` utility function to handle file uploads to Lakehouse.
- Enhanced `JumpstartInstaller` class with `upload_files` method to orchestrate file uploads.
- Updated configuration schema to include fields for file source and destination paths.
- Added validation for file upload fields in the `JumpstartSource` model.
- Created comprehensive tests for file upload functionality and schema validation.

# Why this change is needed
This feature implements issue #19 (feat: support deploying small files)
It allows jumpstart publishers to upload reference data or sample data that may be needed to initialize a Fabric solution.

If this is a bug fix, please describe

- How the bug was discovered.
- Is there a repro for the bug.

# How
The change introduces 3 optional file upload fields that can be specified in the source object of the jumpstart .yml file:
       - `files_source_path` _(optional)_: Relative path within the repo to a file or folder to upload to a Lakehouse's Files area (e.g., `retail-sales/data/`). Can reference a file or a folder (which will be processed recursively)
       - `files_destination_lakehouse` _(optional)_: Name of the target Lakehouse (must be deployed by the jumpstart). Required if `files_source_path` is set.
       - `files_destination_path` _(optional)_: Destination path within the Lakehouse Files area (defaults to root if omitted)

If the field are specified, the files will be uploaded to the destination Lakehouse after the item deployment (assuming that it is one of the items deployed by the jumpstart).

# Test
A comprehensive suite of 18 unit tests has been added for this feature.

# Closes issue
Fixes #19 feat: support deploying small files
