### PR TITLE
fixes #126 - Mermaid v11's default securityLevel: 'strict' silently d…

### DIFF
--- a/src/fabric_jumpstart_web/src/app/tools/diagram-generator/DiagramGenerator.tsx
+++ b/src/fabric_jumpstart_web/src/app/tools/diagram-generator/DiagramGenerator.tsx
@@ -40,6 +40,7 @@ const SAMPLE_CHART = `graph LR
 
 const MERMAID_CONFIG_LIGHT = {
   startOnLoad: false,
+  securityLevel: 'loose' as const,
   theme: 'base' as const,
   themeVariables: {
     primaryColor: '#f5f8fa',

--- a/src/fabric_jumpstart_web/src/components/MermaidDiagram/index.tsx
+++ b/src/fabric_jumpstart_web/src/components/MermaidDiagram/index.tsx
@@ -28,6 +28,7 @@ export default function MermaidDiagram({ chart, className, bare, seamless }: Mer
       const mermaid = (await import('mermaid')).default;
       mermaid.initialize({
         startOnLoad: false,
+        securityLevel: 'loose' as const,
         theme: 'base',
         themeVariables: {
           primaryColor: isDark ? '#2a2a32' : '#f5f8fa',


### PR DESCRIPTION
Mermaid v11's default securityLevel: 'strict' silently disables htmlLabels and foreignObject — even when htmlLabels: true is explicitly set. The enhance.ts post-processor depends on these elements for icons, gradient fills, custom box styling, and subtitles. In dev mode it worked because Mermaid's global config leaked from scenario pages (which set securityLevel: 'loose'). In production static export, each page loads independently.

Fixes #126 