### PR TITLE
feat: track install counts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 jobs:
@@ -23,4 +25,6 @@ jobs:
       - name: "🚀 Deploy Projects"
         env:
           WEBSITE_STORAGE_CONN_STRING: ${{ secrets.WEBSITE_STORAGE_CONN_STRING }}
+          APPINSIGHTS_APP_ID: ${{ secrets.APPINSIGHTS_APP_ID }}
+          APPINSIGHTS_API_KEY: ${{ secrets.APPINSIGHTS_API_KEY }}
         run: npx nx run-many -t deploy --parallel=3 --output-style=stream

--- a/src/fabric_jumpstart/fabric_jumpstart/core.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/core.py
@@ -8,6 +8,7 @@ from typing import Optional
 from .installer import JumpstartInstaller
 from .logger import log_capture_context
 from .registry import JumpstartRegistry
+from .telemetry import track_install
 from .ui import ConflictUI, render_install_status_html, render_jumpstart_list
 
 logger = logging.getLogger(__name__)
@@ -317,6 +318,14 @@ class jumpstart:
 
                 # Phase 7: Generate entry URL
                 entry_url = installer.generate_entry_url(target_ws, resolved_prefix)
+
+                # Telemetry: record successful install
+                track_install(
+                    jumpstart_id=name,
+                    jumpstart_numeric_id=config.get("id", 0),
+                    jumpstart_type=config.get("type", ""),
+                    status="success",
+                )
                 
                 # Render success — animate progress bar to 100% first
                 current_status['label'] = 'success'  # Prevent on_emit from overwriting
@@ -379,6 +388,12 @@ class jumpstart:
                     return status_html
                     
             except Exception as e:
+                track_install(
+                    jumpstart_id=name,
+                    jumpstart_numeric_id=config.get("id", 0),
+                    jumpstart_type=config.get("type", ""),
+                    status="failure",
+                )
                 logger.exception(f"Failed to install jumpstart '{name}'")
                 error_text = str(e).strip() or e.__class__.__name__
                 

--- a/src/fabric_jumpstart/fabric_jumpstart/telemetry.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/telemetry.py
@@ -1,0 +1,122 @@
+"""Lightweight telemetry for jumpstart install events.
+
+Events are sent to Azure Application Insights via the REST Track API.
+The ingestion connection string is *not* a secret — it is a write-only
+public identifier, the same pattern used by the App Insights JS SDK in
+browsers and by Google Analytics tracking IDs.
+
+Telemetry can be disabled by setting the environment variable
+``JUMPSTART_TELEMETRY_OPTOUT=1``.  The connection string can be
+overridden via ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.request
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONNECTION_STRING = "InstrumentationKey=d7c982d9-221f-4bf8-b4be-93ae54703f5f;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=5bd92c67-500e-4d3d-b282-80680dfc9b20"
+
+_TRACK_PATH = "/v2/track"
+
+
+def _parse_connection_string(conn_str: str) -> tuple[str, str]:
+    """Return (ingestion_endpoint, instrumentation_key) from a connection string."""
+    parts: dict[str, str] = {}
+    for segment in conn_str.split(";"):
+        if "=" in segment:
+            key, _, value = segment.partition("=")
+            parts[key.strip()] = value.strip()
+
+    ikey = parts.get("InstrumentationKey", "")
+    endpoint = parts.get("IngestionEndpoint", "https://dc.services.visualstudio.com").rstrip("/")
+    return endpoint, ikey
+
+
+def _get_connection_string() -> Optional[str]:
+    """Resolve the connection string, respecting opt-out and overrides."""
+    if os.environ.get("JUMPSTART_TELEMETRY_OPTOUT", "").strip() in ("1", "true", "yes"):
+        return None
+    return (
+        os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
+        or _DEFAULT_CONNECTION_STRING
+        or None
+    )
+
+
+def _build_envelope(
+    ikey: str,
+    event_name: str,
+    properties: dict[str, str],
+) -> dict:
+    """Build an Application Insights Track API envelope."""
+    return {
+        "name": "Microsoft.ApplicationInsights.Event",
+        "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "iKey": ikey,
+        "data": {
+            "baseType": "EventData",
+            "baseData": {
+                "ver": 2,
+                "name": event_name,
+                "properties": properties,
+            },
+        },
+    }
+
+
+def _send(endpoint: str, payload: bytes) -> None:
+    """POST payload to the App Insights ingestion endpoint (best-effort)."""
+    req = urllib.request.Request(
+        f"{endpoint}{_TRACK_PATH}",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=3)
+    except Exception:
+        pass
+
+
+def track_install(
+    jumpstart_id: str,
+    jumpstart_numeric_id: int,
+    jumpstart_type: str,
+    status: str,
+) -> None:
+    """Record a jumpstart install event (fire-and-forget).
+
+    This never raises and never blocks the install flow.  The HTTP call
+    runs on a daemon thread so the caller returns immediately.
+    """
+    try:
+        conn_str = _get_connection_string()
+        if not conn_str:
+            return
+
+        endpoint, ikey = _parse_connection_string(conn_str)
+        if not ikey:
+            return
+
+        envelope = _build_envelope(
+            ikey=ikey,
+            event_name="jumpstart_installed",
+            properties={
+                "jumpstart_id": jumpstart_id,
+                "jumpstart_numeric_id": str(jumpstart_numeric_id),
+                "type": jumpstart_type,
+                "status": status,
+            },
+        )
+        payload = json.dumps(envelope).encode("utf-8")
+
+        t = threading.Thread(target=_send, args=(endpoint, payload), daemon=True)
+        t.start()
+    except Exception:
+        pass

--- a/src/fabric_jumpstart_web/project.json
+++ b/src/fabric_jumpstart_web/project.json
@@ -17,7 +17,7 @@
     },
     "generate-content": {
       "executor": "nx:run-commands",
-      "cache": true,
+      "cache": false,
       "options": {
         "cwd": "src/fabric_jumpstart_web",
         "commands": ["npx tsx scripts/generate-content.ts"],

--- a/src/fabric_jumpstart_web/scripts/generate-content.ts
+++ b/src/fabric_jumpstart_web/scripts/generate-content.ts
@@ -314,8 +314,73 @@ function generateScenariosJson(scenarios: TaggedScenarioYml[]): ScenarioCard[] {
         core: s._core,
         isNew: isNewJumpstart(s.date_added),
         mermaid_diagram: s.mermaid_diagram || '',
+        installCount: 0,
       };
     });
+}
+
+// ─── Install counts from Application Insights ───────────────
+
+async function fetchInstallCounts(): Promise<Record<string, number>> {
+  const appId = process.env.APPINSIGHTS_APP_ID?.trim();
+  const apiKey = process.env.APPINSIGHTS_API_KEY?.trim();
+
+  if (!appId || !apiKey) {
+    console.log('  ⚠ APPINSIGHTS_APP_ID / APPINSIGHTS_API_KEY not set — skipping install counts');
+    return {};
+  }
+
+  const query = [
+    'customEvents',
+    '| where name == "jumpstart_installed"',
+    '| extend jumpstart_id = tostring(customDimensions.jumpstart_id),',
+    '         status = tostring(customDimensions.status)',
+    '| where status == "success"',
+    '| summarize install_count = count() by jumpstart_id',
+  ].join('\n');
+
+  const url = `https://api.applicationinsights.io/v1/apps/${appId}/query`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!res.ok) {
+      console.log(`  ⚠ App Insights query failed (HTTP ${res.status}) — skipping install counts`);
+      return {};
+    }
+
+    const json = (await res.json()) as {
+      tables: Array<{ columns: Array<{ name: string }>; rows: Array<Array<string | number>> }>;
+    };
+
+    const table = json.tables?.[0];
+    if (!table) return {};
+
+    const idIdx = table.columns.findIndex((c) => c.name === 'jumpstart_id');
+    const countIdx = table.columns.findIndex((c) => c.name === 'install_count');
+    if (idIdx < 0 || countIdx < 0) return {};
+
+    const counts: Record<string, number> = {};
+    for (const row of table.rows) {
+      const id = String(row[idIdx]);
+      const count = Number(row[countIdx]);
+      if (id && count > 0) counts[id] = count;
+    }
+
+    console.log(`  Fetched install counts for ${Object.keys(counts).length} jumpstarts`);
+    return counts;
+  } catch (err) {
+    console.log(`  ⚠ App Insights query error — skipping install counts: ${err}`);
+    return {};
+  }
 }
 
 // ─── Workload color extraction ────────────────────────────────
@@ -453,6 +518,46 @@ async function main(): Promise<void> {
   console.log('  Generated side-menu.json');
 
   const scenariosJson = generateScenariosJson(scenarios);
+
+  // Merge install counts from Application Insights
+  const installCounts = await fetchInstallCounts();
+  if (Object.keys(installCounts).length > 0) {
+    for (const card of scenariosJson) {
+      card.installCount = installCounts[card.id] ?? 0;
+    }
+  } else {
+    // No fresh counts available — preserve existing counts from previous build
+    const scenariosPath = path.join(DATA_DIR, 'scenarios.json');
+    if (fs.existsSync(scenariosPath)) {
+      try {
+        const existing = JSON.parse(fs.readFileSync(scenariosPath, 'utf-8')) as ScenarioCard[];
+        const prevCounts = new Map(existing.map((s) => [s.id, s.installCount ?? 0]));
+        for (const card of scenariosJson) {
+          card.installCount = prevCounts.get(card.id) ?? 0;
+        }
+        console.log('  Preserved install counts from previous build');
+      } catch {
+        // If we can't read the previous file, leave counts at 0
+      }
+    }
+  }
+
+  // Apply migration offsets from previous App Insights workspaces
+  const offsetsPath = path.join(DATA_DIR, 'install-count-offsets.json');
+  if (fs.existsSync(offsetsPath)) {
+    try {
+      const offsets = JSON.parse(fs.readFileSync(offsetsPath, 'utf-8')) as Record<string, number>;
+      for (const card of scenariosJson) {
+        const offset = offsets[card.id];
+        if (offset && offset > 0) {
+          card.installCount += offset;
+        }
+      }
+    } catch {
+      // Ignore malformed offsets file
+    }
+  }
+
   fs.writeFileSync(
     path.join(DATA_DIR, 'scenarios.json'),
     JSON.stringify(scenariosJson, null, 2)

--- a/src/fabric_jumpstart_web/src/app/catalog/ScenarioGrid.tsx
+++ b/src/fabric_jumpstart_web/src/app/catalog/ScenarioGrid.tsx
@@ -109,6 +109,8 @@ export default function ScenarioGrid() {
           if (fa !== fb) return fa - fb;
           return b.lastUpdated.localeCompare(a.lastUpdated);
         }
+        case 'popularity':
+          return (b.installCount ?? 0) - (a.installCount ?? 0);
         case 'newest':
           return b.lastUpdated.localeCompare(a.lastUpdated);
         case 'oldest':

--- a/src/fabric_jumpstart_web/src/components/JumpstartCard/index.tsx
+++ b/src/fabric_jumpstart_web/src/components/JumpstartCard/index.tsx
@@ -41,6 +41,12 @@ export function getDifficultyTooltip(difficulty: string): string {
   }
 }
 
+export function formatInstallCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+  return String(count);
+}
+
 interface JumpstartCardProps {
   scenario: ScenarioCard;
   isDark: boolean;
@@ -158,26 +164,58 @@ function CardHeader({
           </div>
         )}
       </div>
-      {/* NEW badge */}
-      {isNew && (
+      {/* Top-right badges: install count + NEW */}
+      {((scenario.installCount ?? 0) > 0 || isNew) && (
         <div
           style={{
             position: 'absolute',
             top: '6px',
             right: '6px',
             zIndex: 2,
-            backgroundColor: '#212121',
-            color: '#FFFFFF',
-            border: isDark ? '1px solid #e0e0e0' : 'none',
-            padding: '2px 12px',
-            borderRadius: '2px',
-            fontSize: '11px',
-            fontWeight: 700,
-            textTransform: 'uppercase' as const,
-            letterSpacing: '0.5px',
+            display: 'flex',
+            gap: '6px',
+            alignItems: 'center',
           }}
         >
-          NEW
+          {(scenario.installCount ?? 0) > 0 && (
+            <div
+              style={{
+                backgroundColor: isDark ? '#212121' : '#FFFFFF',
+                color: isDark ? '#FFFFFF' : '#212121',
+                border: isDark ? '1px solid #e0e0e0' : '1px solid rgba(0,0,0,0.12)',
+                padding: '2px 10px',
+                borderRadius: '2px',
+                fontSize: '11px',
+                fontWeight: 700,
+                letterSpacing: '0.3px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                <path d="M8 1v10M4 8l4 4 4-4M2 14h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              {formatInstallCount(scenario.installCount)}
+            </div>
+          )}
+          {isNew && (
+            <div
+              style={{
+                backgroundColor: '#212121',
+                color: '#FFFFFF',
+                border: isDark ? '1px solid #e0e0e0' : 'none',
+                padding: '2px 12px',
+                borderRadius: '2px',
+                fontSize: '11px',
+                fontWeight: 700,
+                textTransform: 'uppercase' as const,
+                letterSpacing: '0.5px',
+              }}
+            >
+              NEW
+            </div>
+          )}
         </div>
       )}
       {/* Workload ribbon */}

--- a/src/fabric_jumpstart_web/src/components/Providers/filterProvider.tsx
+++ b/src/fabric_jumpstart_web/src/components/Providers/filterProvider.tsx
@@ -29,10 +29,12 @@ export type SortOption =
   | 'newest'
   | 'oldest'
   | 'name-asc'
-  | 'name-desc';
+  | 'name-desc'
+  | 'popularity';
 
 export const sortLabels: Record<SortOption, string> = {
   featured: 'Featured first',
+  popularity: 'Most installed',
   newest: 'Newest first',
   oldest: 'Oldest first',
   'name-asc': 'Name (A–Z)',

--- a/src/fabric_jumpstart_web/src/data/install-count-offsets.json
+++ b/src/fabric_jumpstart_web/src/data/install-count-offsets.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Install count offsets from previous Application Insights workspace migrations. Values here are added to the live counts from the current App Insights instance.",
+  "stateful-streaming-lakehouse": 1,
+  "healthcare-billing-system": 0,
+  "fpm-capacity-events": 0,
+  "fpm-activity-events": 0,
+  "fpm-fabric-inventory": 0,
+  "fpm-gateway-monitoring": 0,
+  "banking-loan-fraud": 0,
+  "retail-sales": 0,
+  "fpm-workspace-item-events": 0,
+  "stateful-streaming-rocksdb": 0,
+  "spark-monitoring-and-optimization": 0,
+  "telecom-call-data-records": 0,
+  "materialized-lake-views": 0,
+  "fabric-cost-analysis": 0,
+  "grid-intelligence": 0,
+  "multivariate-anomaly-detection": 0
+}

--- a/src/fabric_jumpstart_web/src/types/scenario.ts
+++ b/src/fabric_jumpstart_web/src/types/scenario.ts
@@ -82,4 +82,5 @@ export class ScenarioCard {
   core: boolean = true;
   isNew: boolean = false;
   mermaid_diagram: string = '';
+  installCount: number = 0;
 }


### PR DESCRIPTION
This pull request introduces telemetry for tracking successful and failed jumpstart installs, and surfaces install counts in the web catalog UI. It also enables scheduled deployments, improves data resilience for install counts, and adds a new "popularity" sort option in the catalog. The changes span backend telemetry, build scripts, and frontend UI updates.

**Telemetry and Install Count Tracking:**
- Added lightweight telemetry for jumpstart install events, sending data to Azure Application Insights. This includes a new `track_install` function in `telemetry.py` and integration into the install flow for both successes and failures. Telemetry can be disabled or configured via environment variables. [[1]](diffhunk://#diff-85aa147115c6eca0288ddc31914c554ea54ccce7edd7225267776bf89ed1f20cR11) [[2]](diffhunk://#diff-85aa147115c6eca0288ddc31914c554ea54ccce7edd7225267776bf89ed1f20cR322-R329) [[3]](diffhunk://#diff-85aa147115c6eca0288ddc31914c554ea54ccce7edd7225267776bf89ed1f20cR391-R396) [[4]](diffhunk://#diff-d072bf37a03a6400affa9d878e3cd6e2a1d00e10a6ac0b709a3d3b4fc82d389bR1-R122)
- The web build script (`generate-content.ts`) now fetches install counts from Application Insights and merges them into `scenarios.json`. If live data isn't available, it preserves previous counts or applies migration offsets from a new `install-count-offsets.json` file. [[1]](diffhunk://#diff-4521ccf0f0084c10b2f9fa4e1c50630f245cd0a48dae32fde663a2134431ce2dR317-R385) [[2]](diffhunk://#diff-4521ccf0f0084c10b2f9fa4e1c50630f245cd0a48dae32fde663a2134431ce2dR521-R560) [[3]](diffhunk://#diff-6c0ccd7305a4ed1315d3c07ad893080cca4b2f2e46a5760a906c596a4550a3a8R1-R19)

**Frontend Catalog Enhancements:**
- The `ScenarioCard` model, card component, and grid now display install counts, including a formatted badge on each card. A utility function formats large counts for display. [[1]](diffhunk://#diff-dbef9bbab1ec8d6963fc5ae048f0595b28a02bb9e3209ca93a0e2cc01856c6cdR85) [[2]](diffhunk://#diff-2db20b5a59865ea604ed33c3d8c361f2737834feb7392230e25e46d8f431bf46R44-R49) [[3]](diffhunk://#diff-2db20b5a59865ea604ed33c3d8c361f2737834feb7392230e25e46d8f431bf46L161-R204) [[4]](diffhunk://#diff-2db20b5a59865ea604ed33c3d8c361f2737834feb7392230e25e46d8f431bf46R219-R220)
- Added a "popularity" sort option to the catalog, sorting by install count, and surfaced it in the UI sort options. [[1]](diffhunk://#diff-a7cee836b442ddd09be7a4791d377f2dd795e0da76fc2596a6c867ca8f4fa48cL32-R37) [[2]](diffhunk://#diff-b240e9429e6b712dcb27c164b3574e1086acfdf0eec7cac7066f05d7bd5e1bbfR112-R113)

**Build and Deployment Improvements:**
- The deploy workflow now runs on a schedule (daily at 6:00 UTC) and passes Application Insights credentials for install count queries. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R7-R8) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R28-R29)
- Disabled caching for the `generate-content` build step to ensure fresh data is always used for install counts.

---

**Telemetry and Analytics Integration**
- Added `track_install` telemetry function to `telemetry.py` and integrated it into the jumpstart install flow to record both successful and failed installs, with opt-out and connection string override support. [[1]](diffhunk://#diff-85aa147115c6eca0288ddc31914c554ea54ccce7edd7225267776bf89ed1f20cR11) [[2]](diffhunk://#diff-85aa147115c6eca0288ddc31914c554ea54ccce7edd7225267776bf89ed1f20cR322-R329) [[3]](diffhunk://#diff-85aa147115c6eca0288ddc31914c554ea54ccce7edd7225267776bf89ed1f20cR391-R396) [[4]](diffhunk://#diff-d072bf37a03a6400affa9d878e3cd6e2a1d00e10a6ac0b709a3d3b4fc82d389bR1-R122)
- Build script now queries Application Insights for install counts and merges them into `scenarios.json`, with fallback to previous counts or migration offsets from `install-count-offsets.json`. [[1]](diffhunk://#diff-4521ccf0f0084c10b2f9fa4e1c50630f245cd0a48dae32fde663a2134431ce2dR317-R385) [[2]](diffhunk://#diff-4521ccf0f0084c10b2f9fa4e1c50630f245cd0a48dae32fde663a2134431ce2dR521-R560) [[3]](diffhunk://#diff-6c0ccd7305a4ed1315d3c07ad893080cca4b2f2e46a5760a906c596a4550a3a8R1-R19)

**Frontend Catalog Updates**
- Display install counts on scenario cards, including a formatted badge and a utility to format large numbers. [[1]](diffhunk://#diff-dbef9bbab1ec8d6963fc5ae048f0595b28a02bb9e3209ca93a0e2cc01856c6cdR85) [[2]](diffhunk://#diff-2db20b5a59865ea604ed33c3d8c361f2737834feb7392230e25e46d8f431bf46R44-R49) [[3]](diffhunk://#diff-2db20b5a59865ea604ed33c3d8c361f2737834feb7392230e25e46d8f431bf46L161-R204) [[4]](diffhunk://#diff-2db20b5a59865ea604ed33c3d8c361f2737834feb7392230e25e46d8f431bf46R219-R220)
- Added "popularity" sort option to the catalog, sorting scenarios by install count. [[1]](diffhunk://#diff-a7cee836b442ddd09be7a4791d377f2dd795e0da76fc2596a6c867ca8f4fa48cL32-R37) [[2]](diffhunk://#diff-b240e9429e6b712dcb27c164b3574e1086acfdf0eec7cac7066f05d7bd5e1bbfR112-R113)

**Build and Deployment**
- Scheduled the deploy workflow to run daily and added Application Insights credentials to the deploy environment. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R7-R8) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R28-R29)
- Disabled caching for the `generate-content` step to ensure up-to-date install counts on every build.

closes #128 