### PR TITLE
feat: fabric-cicd upgrade and silence version check

### DIFF
--- a/src/fabric_jumpstart/fabric_jumpstart/__init__.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/__init__.py
@@ -1,4 +1,7 @@
 from .core import jumpstart as _Jumpstart
+import os
+
+os.environ["FABRIC_CICD_VERSION_CHECK_DISABLED"] = "1"
 
 # Singleton instance used for convenience imports
 jumpstart = _Jumpstart()

--- a/src/fabric_jumpstart/fabric_jumpstart/utils.py
+++ b/src/fabric_jumpstart/fabric_jumpstart/utils.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import logging
 import os
 import shutil
@@ -24,37 +26,46 @@ _CREDENTIAL_CLASS_MAP = {
 
 
 def resolve_token_credential():
-    """Resolve a token credential from the environment variable.
+    """Resolve a token credential for Fabric API access.
 
-    Reads ``FABRIC_JUMPSTART_TOKEN_CREDENTIAL`` and returns the corresponding
-    ``azure.identity`` credential instance, or ``None`` when the variable is
-    unset (preserving the default behaviour of ``fabric_cicd``).
+    Resolution order:
+    1. ``FABRIC_JUMPSTART_TOKEN_CREDENTIAL`` environment variable
+    2. Fabric notebook runtime (auto-generates a credential via ``notebookutils``)
+    3. ``DefaultAzureCredential`` (fallback)
 
     Returns:
-        A ``TokenCredential`` instance or ``None``.
+        A ``TokenCredential`` instance.
 
     Raises:
         ValueError: If the env-var value is not in the supported set.
     """
     override = os.environ.get(CREDENTIAL_OVERRIDE_ENV_VAR)
-    if not override:
-        return None
+    if override:
+        qualified = _CREDENTIAL_CLASS_MAP.get(override)
+        if qualified is None:
+            supported = ", ".join(sorted(_CREDENTIAL_CLASS_MAP))
+            raise ValueError(
+                f"Unsupported {CREDENTIAL_OVERRIDE_ENV_VAR} value '{override}'. "
+                f"Supported values: {supported}"
+            )
 
-    qualified = _CREDENTIAL_CLASS_MAP.get(override)
-    if qualified is None:
-        supported = ", ".join(sorted(_CREDENTIAL_CLASS_MAP))
-        raise ValueError(
-            f"Unsupported {CREDENTIAL_OVERRIDE_ENV_VAR} value '{override}'. "
-            f"Supported values: {supported}"
-        )
+        module_path, class_name = qualified.rsplit(".", 1)
+        import importlib
+        module = importlib.import_module(module_path)
+        cls = getattr(module, class_name)
+        credential = cls()
+        logger.info("Using %s credential from %s", override, CREDENTIAL_OVERRIDE_ENV_VAR)
+        return credential
 
-    module_path, class_name = qualified.rsplit(".", 1)
-    import importlib
-    module = importlib.import_module(module_path)
-    cls = getattr(module, class_name)
-    credential = cls()
-    logger.info("Using %s credential from %s", override, CREDENTIAL_OVERRIDE_ENV_VAR)
-    return credential
+    if _is_fabric_runtime():
+        logger.info("Fabric runtime detected; using FabricTokenCredential")
+        return _generate_fabric_credential()
+
+    # Lazy import to avoid errors in Fabric notebook environments
+    from azure.identity import DefaultAzureCredential
+
+    logger.info("Using DefaultAzureCredential")
+    return DefaultAzureCredential()
 
 
 def _is_fabric_runtime() -> bool:
@@ -68,6 +79,70 @@ def _is_fabric_runtime() -> bool:
         return False
     except Exception:
         return False
+
+
+def _decode_jwt(token: str) -> dict:
+    """Decode a JWT token and return the payload as a dictionary.
+
+    Args:
+        token: The JWT token to decode.
+
+    Returns:
+        Decoded payload dictionary.
+
+    Raises:
+        ValueError: If the token has an invalid JWT format.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("The token has an invalid JWT format")
+
+    payload = parts[1]
+    padding = "=" * (4 - len(payload) % 4)
+    payload += padding
+    decoded_bytes = base64.urlsafe_b64decode(payload.encode("utf-8"))
+    decoded_str = decoded_bytes.decode("utf-8")
+    return json.loads(decoded_str)
+
+
+def _generate_fabric_credential():
+    """Generate a TokenCredential for Fabric using notebookutils.
+
+    Returns a credential that retrieves tokens from the Fabric notebook
+    runtime via ``notebookutils.credentials.getToken``.
+    """
+    from datetime import datetime, timezone
+
+    class FabricTokenCredential:
+        """Custom credential that uses notebookutils to get tokens."""
+
+        def __init__(self, audience: str = "pbi") -> None:
+            self.audience = audience
+
+        def get_token(self, *scopes, **kwargs):
+            """Get token using notebookutils."""
+            import notebookutils  # type: ignore[import-untyped]
+
+            token_string = notebookutils.credentials.getToken(self.audience)
+
+            try:
+                payload = _decode_jwt(token_string)
+                expires_on = payload.get("exp")
+                if expires_on:
+                    from azure.core.credentials import AccessToken
+
+                    return AccessToken(token_string, expires_on)
+            except Exception:
+                pass  # Fall back to default expiration
+
+            from azure.core.credentials import AccessToken
+
+            return AccessToken(
+                token_string,
+                int(datetime.now(timezone.utc).timestamp()) + 3600,
+            )
+
+    return FabricTokenCredential("pbi")
 
 def download_file(url: str, dest: str):
     with requests.get(url, stream=True) as r:

--- a/src/fabric_jumpstart/pyproject.toml
+++ b/src/fabric_jumpstart/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "fabric-cicd==0.3.1", # for testing local build: "fabric-cicd @ file:///C:/.../fabric-cicd/dist/fabric_cicd-0.1.34-py3-none-any.whl",
     "ipython>=8.20.0",
-    "pyyaml>=6.0.3",
+    "pyyaml>=6.0.2",
 ]
 
 [tool.hatch.build]

--- a/src/fabric_jumpstart/pyproject.toml
+++ b/src/fabric_jumpstart/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "fabric-cicd==0.3.1", # for testing local build: "fabric-cicd @ file:///C:/.../fabric-cicd/dist/fabric_cicd-0.1.34-py3-none-any.whl",
+    "fabric-cicd==1.0.0", # for testing local build: "fabric-cicd @ file:///C:/.../fabric-cicd/dist/fabric_cicd-0.1.34-py3-none-any.whl",
     "ipython>=8.20.0",
     "pyyaml>=6.0.2",
 ]

--- a/src/fabric_jumpstart/tests/test_credential.py
+++ b/src/fabric_jumpstart/tests/test_credential.py
@@ -1,28 +1,74 @@
 """Tests for token credential resolution via environment variable."""
 
+import base64
+import json
 import os
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from fabric_jumpstart.utils import (
     CREDENTIAL_OVERRIDE_ENV_VAR,
+    _decode_jwt,
+    _generate_fabric_credential,
     resolve_token_credential,
 )
+
+
+def _make_mock_jwt(claims=None):
+    """Create a mock JWT token string with the given claims."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "HS256", "typ": "JWT"}).encode()
+    ).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(claims or {"exp": 9999999999}).encode()
+    ).decode().rstrip("=")
+    signature = base64.urlsafe_b64encode(b"signature").decode().rstrip("=")
+    return f"{header}.{payload}.{signature}"
 
 
 class TestResolveTokenCredential:
     """Tests for resolve_token_credential()."""
 
-    def test_returns_none_when_env_var_unset(self):
-        """No env var → None (default fabric_cicd behaviour)."""
-        with patch.dict(os.environ, {}, clear=True):
-            assert resolve_token_credential() is None
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.DefaultAzureCredential", create=True)
+    def test_returns_default_credential_when_env_var_unset(self, mock_dac_cls, mock_runtime):
+        """No env var and not in Fabric → DefaultAzureCredential."""
+        mock_instance = MagicMock()
+        mock_dac_cls.return_value = mock_instance
 
-    def test_returns_none_when_env_var_empty(self):
-        """Empty env var → None."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("azure.identity.DefaultAzureCredential", mock_dac_cls):
+                result = resolve_token_credential()
+
+        assert result is mock_instance
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=False)
+    @patch("fabric_jumpstart.utils.DefaultAzureCredential", create=True)
+    def test_returns_default_credential_when_env_var_empty(self, mock_dac_cls, mock_runtime):
+        """Empty env var → DefaultAzureCredential."""
+        mock_instance = MagicMock()
+        mock_dac_cls.return_value = mock_instance
+
         with patch.dict(os.environ, {CREDENTIAL_OVERRIDE_ENV_VAR: ""}):
-            assert resolve_token_credential() is None
+            with patch("azure.identity.DefaultAzureCredential", mock_dac_cls):
+                result = resolve_token_credential()
+
+        assert result is mock_instance
+
+    @patch("fabric_jumpstart.utils._is_fabric_runtime", return_value=True)
+    @patch("fabric_jumpstart.utils._generate_fabric_credential")
+    def test_returns_fabric_credential_in_fabric_runtime(self, mock_gen, mock_runtime):
+        """In Fabric runtime without env var → FabricTokenCredential."""
+        mock_cred = MagicMock()
+        mock_gen.return_value = mock_cred
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = resolve_token_credential()
+
+        mock_gen.assert_called_once()
+        assert result is mock_cred
 
     def test_returns_azure_cli_credential(self):
         """AzureCliCredential env var → instantiated credential."""
@@ -58,27 +104,70 @@ class TestResolveTokenCredential:
                 resolve_token_credential()
 
 
+class TestDecodeJwt:
+    """Tests for _decode_jwt()."""
+
+    def test_decode_valid_jwt(self):
+        """Valid JWT → decoded payload dict."""
+        claims = {"exp": 9999999999, "upn": "user@example.com"}
+        token = _make_mock_jwt(claims)
+        result = _decode_jwt(token)
+        assert result["exp"] == 9999999999
+        assert result["upn"] == "user@example.com"
+
+    def test_decode_invalid_jwt_format(self):
+        """Invalid JWT format → ValueError."""
+        with pytest.raises(ValueError, match="invalid JWT format"):
+            _decode_jwt("not.a.valid.jwt.token")
+
+    def test_decode_two_part_token(self):
+        """Two-part token → ValueError."""
+        with pytest.raises(ValueError, match="invalid JWT format"):
+            _decode_jwt("header.payload")
+
+
+class TestGenerateFabricCredential:
+    """Tests for _generate_fabric_credential()."""
+
+    def test_credential_returns_token_with_expiration(self):
+        """Credential get_token() returns AccessToken with JWT expiration."""
+        import sys
+
+        mock_jwt = _make_mock_jwt({"exp": 9999999999})
+        mock_notebookutils = MagicMock()
+        mock_notebookutils.credentials.getToken.return_value = mock_jwt
+
+        with patch.dict(sys.modules, {"notebookutils": mock_notebookutils}):
+            credential = _generate_fabric_credential()
+            token = credential.get_token()
+
+        assert token.token == mock_jwt
+        assert token.expires_on == 9999999999
+        mock_notebookutils.credentials.getToken.assert_called_once_with("pbi")
+
+    def test_credential_fallback_expiration(self):
+        """When JWT parsing fails, uses fallback expiration (~1 hour)."""
+        import sys
+
+        mock_notebookutils = MagicMock()
+        mock_notebookutils.credentials.getToken.return_value = "invalid.jwt.token"
+
+        with patch.dict(sys.modules, {"notebookutils": mock_notebookutils}):
+            credential = _generate_fabric_credential()
+            current_time = int(time.time())
+            token = credential.get_token()
+
+        assert token.expires_on >= current_time + 3500
+        assert token.expires_on <= current_time + 3700
+
+
 class TestWorkspaceManagerCredentialPassthrough:
     """Ensure WorkspaceManager passes resolved credential to FabricWorkspace."""
 
-    @patch("fabric_jumpstart.workspace_manager.resolve_token_credential", return_value=None)
-    @patch("fabric_jumpstart.workspace_manager.FabricWorkspace")
-    def test_no_credential_when_env_var_unset(self, mock_fw, mock_resolve):
-        """When resolver returns None, token_credential=None is passed (fabric_cicd default)."""
-        from fabric_jumpstart.workspace_manager import WorkspaceManager
-        from pathlib import Path
-
-        wm = WorkspaceManager("ws-id", Path("/tmp"), ["Notebook"])
-        wm.get_fabric_workspace()
-
-        mock_fw.assert_called_once()
-        call_kwargs = mock_fw.call_args[1]
-        assert call_kwargs["token_credential"] is None
-
     @patch("fabric_jumpstart.workspace_manager.resolve_token_credential")
     @patch("fabric_jumpstart.workspace_manager.FabricWorkspace")
-    def test_credential_passed_when_resolved(self, mock_fw, mock_resolve):
-        """When resolver returns a credential, it is forwarded to FabricWorkspace."""
+    def test_credential_passed_to_fabric_workspace(self, mock_fw, mock_resolve):
+        """Resolved credential is forwarded to FabricWorkspace."""
         from fabric_jumpstart.workspace_manager import WorkspaceManager
         from pathlib import Path
 

--- a/src/fabric_jumpstart/uv.lock
+++ b/src/fabric_jumpstart/uv.lock
@@ -337,7 +337,7 @@ test = [
 requires-dist = [
     { name = "fabric-cicd", specifier = "==0.3.1" },
     { name = "ipython", specifier = ">=8.20.0" },
-    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
 ]
 
 [package.metadata.requires-dev]

--- a/src/fabric_jumpstart/uv.lock
+++ b/src/fabric_jumpstart/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "fabric-cicd"
-version = "0.3.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity" },
@@ -303,7 +303,7 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/f3/a00521aefbfac0795f64e03e82fbbca8708ae01dd6eb58fc735d35bdc85f/fabric_cicd-0.3.1-py3-none-any.whl", hash = "sha256:450ff1cb28799ec97d6086d354479b8211a34ac47770ca31bce15ba3291ef5df", size = 114955, upload-time = "2026-03-12T00:59:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/16/a9bb520472d059dab6f773673e9e631352a886f062e3e9374923e6b820d2/fabric_cicd-1.0.0-py3-none-any.whl", hash = "sha256:25b1b78c2f79bc8ab4c38ef045502badc550ad02e1d53362c5993d7ac364e51b", size = 120048, upload-time = "2026-04-20T14:11:04.049Z" },
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fabric-cicd", specifier = "==0.3.1" },
+    { name = "fabric-cicd", specifier = "==1.0.0" },
     { name = "ipython", specifier = ">=8.20.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
 ]


### PR DESCRIPTION
This pull request updates the token credential resolution logic for Fabric Jumpstart to provide improved support for Microsoft Fabric notebook environments, and enhances test coverage for these changes. The main changes include a new credential fallback order, the introduction of a custom Fabric notebook credential, and additional utilities and tests for JWT handling.

**Credential resolution improvements:**

* The `resolve_token_credential` function in `utils.py` now falls back to a custom Fabric notebook credential if running inside a Fabric runtime, and otherwise uses `DefaultAzureCredential` as the default. The previous behavior of returning `None` is replaced with always returning a valid credential. [[1]](diffhunk://#diff-2ea85109ad14013b9efa1b50a1586388522211cfcdca57e4db27a2410d485068L27-R43) [[2]](diffhunk://#diff-2ea85109ad14013b9efa1b50a1586388522211cfcdca57e4db27a2410d485068R60-R69)
* Added `_generate_fabric_credential`, which defines a `FabricTokenCredential` class that retrieves tokens from the Fabric notebook environment using `notebookutils`, and uses JWT expiration if available.
* Added `_decode_jwt` utility to decode JWT tokens and extract claims such as expiration.

**Dependency and environment updates:**

* Updated `pyproject.toml` to require `fabric-cicd==1.0.0` (was `0.3.1`).
* Set the environment variable `FABRIC_CICD_VERSION_CHECK_DISABLED` to `1` in `__init__.py` to disable version checks.

**Testing enhancements:**

* Added comprehensive tests for the new credential resolution logic, including scenarios for environment variable overrides, Fabric runtime detection, and JWT decoding. [[1]](diffhunk://#diff-6ff2c26420ff7df16e4106398b299b260d9ef41b1861845bcec3098b23929932R3-R71) [[2]](diffhunk://#diff-6ff2c26420ff7df16e4106398b299b260d9ef41b1861845bcec3098b23929932L61-R170)
* Added tests for the new `_decode_jwt` and `_generate_fabric_credential` utilities, including fallback behavior and expiration handling.

These changes ensure robust authentication handling across different execution environments, especially for Microsoft Fabric notebooks.

closes #132 