### PR TITLE
feat: support query parameters

### DIFF
--- a/src/fabric_jumpstart_web/__tests__/filterUrlSync.test.ts
+++ b/src/fabric_jumpstart_web/__tests__/filterUrlSync.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for filterUrlSync serialization helpers.
+ * Tests that filters round-trip correctly through URL params.
+ */
+
+import { filtersToSearchParams, searchParamsToFilters, searchParamsEqual } from '@utils/filterUrlSync';
+import { emptyFilters } from '@utils/filterTypes';
+import type { FilterState, SortOption } from '@utils/filterTypes';
+
+describe('filtersToSearchParams', () => {
+  it('produces no params for default/empty filter state', () => {
+    const params = filtersToSearchParams(emptyFilters, 'featured');
+    expect(params.toString()).toBe('');
+  });
+
+  it('encodes search string', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, search: 'lakehouse' }, 'featured');
+    expect(params.get('search')).toBe('lakehouse');
+  });
+
+  it('encodes types as comma-separated', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, types: ['Tutorial', 'Demo'] }, 'featured');
+    expect(params.get('type')).toBe('Tutorial,Demo');
+  });
+
+  it('encodes difficulties', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, difficulties: ['Beginner'] }, 'featured');
+    expect(params.get('difficulty')).toBe('Beginner');
+  });
+
+  it('encodes workloadTags', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, workloadTags: ['Power BI', 'Data Engineering'] }, 'featured');
+    expect(params.get('workload')).toBe('Power BI,Data Engineering');
+  });
+
+  it('encodes scenarioTags', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, scenarioTags: ['Streaming'] }, 'featured');
+    expect(params.get('scenario')).toBe('Streaming');
+  });
+
+  it('encodes classes', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, classes: ['Core'] }, 'featured');
+    expect(params.get('class')).toBe('Core');
+  });
+
+  it('encodes minTime and maxTime', () => {
+    const params = filtersToSearchParams({ ...emptyFilters, minMinutesToComplete: 10, maxMinutesToComplete: 45 }, 'featured');
+    expect(params.get('minTime')).toBe('10');
+    expect(params.get('maxTime')).toBe('45');
+  });
+
+  it('omits minTime/maxTime when null', () => {
+    const params = filtersToSearchParams(emptyFilters, 'featured');
+    expect(params.has('minTime')).toBe(false);
+    expect(params.has('maxTime')).toBe(false);
+  });
+
+  it('encodes non-default sort option', () => {
+    const params = filtersToSearchParams(emptyFilters, 'newest');
+    expect(params.get('sort')).toBe('newest');
+  });
+
+  it('omits sort param when sort is "featured" (default)', () => {
+    const params = filtersToSearchParams(emptyFilters, 'featured');
+    expect(params.has('sort')).toBe(false);
+  });
+});
+
+describe('searchParamsToFilters', () => {
+  const makeParams = (obj: Record<string, string>) => new URLSearchParams(obj);
+
+  it('returns empty filters and default sort for empty params', () => {
+    const { filters, sort } = searchParamsToFilters(new URLSearchParams());
+    expect(filters).toEqual(emptyFilters);
+    expect(sort).toBe('featured');
+  });
+
+  it('decodes search', () => {
+    const { filters } = searchParamsToFilters(makeParams({ search: 'lakehouse' }));
+    expect(filters.search).toBe('lakehouse');
+  });
+
+  it('decodes types', () => {
+    const { filters } = searchParamsToFilters(makeParams({ type: 'Tutorial,Demo' }));
+    expect(filters.types).toEqual(['Tutorial', 'Demo']);
+  });
+
+  it('decodes difficulties', () => {
+    const { filters } = searchParamsToFilters(makeParams({ difficulty: 'Beginner,Advanced' }));
+    expect(filters.difficulties).toEqual(['Beginner', 'Advanced']);
+  });
+
+  it('decodes workload tags', () => {
+    const { filters } = searchParamsToFilters(makeParams({ workload: 'Power BI,Data Engineering' }));
+    expect(filters.workloadTags).toEqual(['Power BI', 'Data Engineering']);
+  });
+
+  it('decodes scenario tags', () => {
+    const { filters } = searchParamsToFilters(makeParams({ scenario: 'Streaming,Monitoring' }));
+    expect(filters.scenarioTags).toEqual(['Streaming', 'Monitoring']);
+  });
+
+  it('decodes classes', () => {
+    const { filters } = searchParamsToFilters(makeParams({ class: 'Core,Community' }));
+    expect(filters.classes).toEqual(['Core', 'Community']);
+  });
+
+  it('decodes minTime and maxTime', () => {
+    const { filters } = searchParamsToFilters(makeParams({ minTime: '5', maxTime: '30' }));
+    expect(filters.minMinutesToComplete).toBe(5);
+    expect(filters.maxMinutesToComplete).toBe(30);
+  });
+
+  it('returns null for minTime/maxTime when not present', () => {
+    const { filters } = searchParamsToFilters(new URLSearchParams());
+    expect(filters.minMinutesToComplete).toBeNull();
+    expect(filters.maxMinutesToComplete).toBeNull();
+  });
+
+  it('decodes valid sort option', () => {
+    const { sort } = searchParamsToFilters(makeParams({ sort: 'name-asc' }));
+    expect(sort).toBe('name-asc');
+  });
+
+  it('falls back to "featured" for unknown sort values', () => {
+    const { sort } = searchParamsToFilters(makeParams({ sort: 'invalid-sort' }));
+    expect(sort).toBe('featured');
+  });
+
+  it('ignores unknown params silently', () => {
+    const { filters, sort } = searchParamsToFilters(makeParams({ unknown: 'value', foo: 'bar' }));
+    expect(filters).toEqual(emptyFilters);
+    expect(sort).toBe('featured');
+  });
+
+  it('handles trailing/leading whitespace in comma-separated values', () => {
+    const { filters } = searchParamsToFilters(makeParams({ type: ' Tutorial , Demo ' }));
+    expect(filters.types).toEqual(['Tutorial', 'Demo']);
+  });
+});
+
+describe('round-trip (encode → decode)', () => {
+  const roundTrip = (filters: FilterState, sort: SortOption) => {
+    const encoded = filtersToSearchParams(filters, sort);
+    return searchParamsToFilters(encoded);
+  };
+
+  it('round-trips a fully populated filter state', () => {
+    const filters: FilterState = {
+      search: 'test query',
+      types: ['Tutorial', 'Accelerator'],
+      difficulties: ['Intermediate'],
+      workloadTags: ['Power BI'],
+      scenarioTags: ['Streaming'],
+      classes: ['Core'],
+      minMinutesToComplete: 10,
+      maxMinutesToComplete: 60,
+    };
+    const { filters: decoded, sort } = roundTrip(filters, 'newest');
+    expect(decoded).toEqual(filters);
+    expect(sort).toBe('newest');
+  });
+
+  it('round-trips default/empty state', () => {
+    const { filters, sort } = roundTrip(emptyFilters, 'featured');
+    expect(filters).toEqual(emptyFilters);
+    expect(sort).toBe('featured');
+  });
+});
+
+describe('searchParamsEqual', () => {
+  it('returns true for identical params', () => {
+    const a = new URLSearchParams({ search: 'test', type: 'Tutorial' });
+    const b = new URLSearchParams({ search: 'test', type: 'Tutorial' });
+    expect(searchParamsEqual(a, b)).toBe(true);
+  });
+
+  it('returns false for different params', () => {
+    const a = new URLSearchParams({ search: 'test' });
+    const b = new URLSearchParams({ search: 'other' });
+    expect(searchParamsEqual(a, b)).toBe(false);
+  });
+
+  it('returns true for two empty params', () => {
+    expect(searchParamsEqual(new URLSearchParams(), new URLSearchParams())).toBe(true);
+  });
+});

--- a/src/fabric_jumpstart_web/src/app/catalog/ScenarioGrid.tsx
+++ b/src/fabric_jumpstart_web/src/app/catalog/ScenarioGrid.tsx
@@ -11,6 +11,7 @@ import { useFilterContext } from '@components/Providers/filterProvider';
 import { sortLabels, type SortOption } from '@components/Providers/filterProvider';
 import { getMatchingSlugs } from '@components/SideMenu/SidebarFilters';
 import JumpstartCard from '@components/JumpstartCard';
+import SkeletonCard from '@components/JumpstartCard/SkeletonCard';
 import type { ScenarioCard } from '@scenario/scenario';
 
 const ExpandedModal = dynamic(
@@ -93,7 +94,7 @@ export default function ScenarioGrid() {
   const scenarios = scenariosData as ScenarioCard[];
   const { theme } = useThemeContext();
   const isDark = theme.key === 'dark';
-  const { filters, hasActiveFilters, sort, setSort } = useFilterContext();
+  const { filters, hasActiveFilters, sort, setSort, isInitialized } = useFilterContext();
   const [expandedChart, setExpandedChart] = useState<{ slug: string; title: string } | null>(null);
 
   const matchingSlugs = useMemo(() => getMatchingSlugs(filters), [filters]);
@@ -136,7 +137,7 @@ export default function ScenarioGrid() {
     <div className={styles.container}>
       <div className={styles.toolbar}>
         <span className={styles.resultCount}>
-          {hasActiveFilters ? (
+          {isInitialized && hasActiveFilters ? (
             <>
               Showing{' '}
               <span className={styles.resultCountBold}>{filteredScenarios.length}</span>{' '}
@@ -144,7 +145,8 @@ export default function ScenarioGrid() {
             </>
           ) : (
             <>
-              <span className={styles.resultCountBold}>{scenarios.length}</span> jumpstarts
+              <span className={styles.resultCountBold}>{isInitialized ? scenarios.length : ''}</span>{' '}
+              {isInitialized ? 'jumpstarts' : ''}
             </>
           )}
         </span>
@@ -162,7 +164,13 @@ export default function ScenarioGrid() {
           </select>
         </div>
       </div>
-      {filteredScenarios.length === 0 ? (
+      {!isInitialized ? (
+        <div className={styles.grid}>
+          {Array.from({ length: 12 }).map((_, i) => (
+            <SkeletonCard key={i} isDark={isDark} className={styles.card} />
+          ))}
+        </div>
+      ) : filteredScenarios.length === 0 ? (
         <div
           style={{
             textAlign: 'center',

--- a/src/fabric_jumpstart_web/src/components/Providers/FilterUrlSync.tsx
+++ b/src/fabric_jumpstart_web/src/components/Providers/FilterUrlSync.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useFilterContext } from './filterProvider';
+import { filtersToSearchParams, searchParamsToFilters, searchParamsEqual } from '@utils/filterUrlSync';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Null-rendering component that syncs the catalog filter state with URL query parameters.
+ * Must be rendered inside FilterProvider and wrapped in a React Suspense boundary
+ * (required by useSearchParams in Next.js static export).
+ *
+ * - On mount: reads URL params via useLayoutEffect (before browser paint) and initializes
+ *   filter + sort state to avoid a visible flash of unfiltered content.
+ * - On state change: replaces URL params to keep the address bar in sync.
+ */
+export default function FilterUrlSync() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { filters, setFilters, sort, setSort, setInitialized } = useFilterContext();
+
+  // Tracks whether the sync effect has fired at least once. The first run always
+  // has pre-init empty state and must be skipped to avoid clearing URL params.
+  const initPhaseRef = useRef(true);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Initialize filter state before the browser paints to avoid a visible flash.
+  // useLayoutEffect fires synchronously after DOM mutations, before paint; React
+  // flushes the resulting state update in the same frame so the user never sees
+  // the unfiltered catalog.
+  useLayoutEffect(() => {
+    const { filters: urlFilters, sort: urlSort } = searchParamsToFilters(
+      new URLSearchParams(searchParams.toString())
+    );
+    setFilters(urlFilters);
+    setSort(urlSort);
+    setInitialized();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep URL in sync when filters or sort change.
+  useEffect(() => {
+    // Skip the very first run: it fires with pre-init empty state (before the
+    // useLayoutEffect above has applied URL params), so running it would clear
+    // the URL params. After this first skip the ref stays false for all future runs.
+    if (initPhaseRef.current) {
+      initPhaseRef.current = false;
+      return;
+    }
+
+    const update = () => {
+      const next = filtersToSearchParams(filters, sort);
+      const current = new URLSearchParams(searchParams.toString());
+      if (!searchParamsEqual(next, current)) {
+        const qs = next.toString();
+        router.replace(qs ? `/catalog/?${qs}` : '/catalog/', { scroll: false });
+      }
+    };
+
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(update, filters.search ? SEARCH_DEBOUNCE_MS : 0);
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters, sort]);
+
+  return null;
+}

--- a/src/fabric_jumpstart_web/src/components/Providers/filterProvider.tsx
+++ b/src/fabric_jumpstart_web/src/components/Providers/filterProvider.tsx
@@ -1,45 +1,16 @@
 'use client';
 
 import React, { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import {
+  type FilterState,
+  type SortOption,
+  emptyFilters,
+  sortLabels,
+} from '@utils/filterTypes';
 
-export interface FilterState {
-  search: string;
-  types: string[];
-  difficulties: string[];
-  workloadTags: string[];
-  scenarioTags: string[];
-  minMinutesToComplete: number | null;
-  maxMinutesToComplete: number | null;
-  classes: string[]; // empty = all, ['Core'] or ['Community'] to filter
-}
-
-export const emptyFilters: FilterState = {
-  search: '',
-  types: [],
-  difficulties: [],
-  workloadTags: [],
-  scenarioTags: [],
-  minMinutesToComplete: null,
-  maxMinutesToComplete: null,
-  classes: [],
-};
-
-export type SortOption =
-  | 'featured'
-  | 'newest'
-  | 'oldest'
-  | 'name-asc'
-  | 'name-desc'
-  | 'popularity';
-
-export const sortLabels: Record<SortOption, string> = {
-  featured: 'Featured first',
-  popularity: 'Most installed',
-  newest: 'Newest first',
-  oldest: 'Oldest first',
-  'name-asc': 'Name (A–Z)',
-  'name-desc': 'Name (Z–A)',
-};
+// Re-export for consumers that import from this module.
+export type { FilterState, SortOption };
+export { emptyFilters, sortLabels };
 
 interface FilterContextType {
   filters: FilterState;
@@ -48,6 +19,9 @@ interface FilterContextType {
   clearFilters: () => void;
   sort: SortOption;
   setSort: (sort: SortOption) => void;
+  /** False until URL params have been applied on the client — use to show skeletons. */
+  isInitialized: boolean;
+  setInitialized: () => void;
 }
 
 const FilterContext = createContext<FilterContextType | undefined>(undefined);
@@ -55,6 +29,7 @@ const FilterContext = createContext<FilterContextType | undefined>(undefined);
 export const FilterProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [filters, setFiltersState] = useState<FilterState>({ ...emptyFilters });
   const [sort, setSortState] = useState<SortOption>('featured');
+  const [isInitialized, setIsInitialized] = useState(false);
 
   const hasActiveFilters =
     filters.search !== '' ||
@@ -78,8 +53,12 @@ export const FilterProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     setSortState(next);
   }, []);
 
+  const setInitialized = useCallback(() => {
+    setIsInitialized(true);
+  }, []);
+
   return (
-    <FilterContext.Provider value={{ filters, setFilters, hasActiveFilters, clearFilters, sort, setSort }}>
+    <FilterContext.Provider value={{ filters, setFilters, hasActiveFilters, clearFilters, sort, setSort, isInitialized, setInitialized }}>
       {children}
     </FilterContext.Provider>
   );

--- a/src/fabric_jumpstart_web/src/components/SideMenu/MenuLayout/index.tsx
+++ b/src/fabric_jumpstart_web/src/components/SideMenu/MenuLayout/index.tsx
@@ -1,6 +1,7 @@
 'use client';
-import React from 'react';
+import React, { Suspense } from 'react';
 import { FilterProvider } from '@components/Providers/filterProvider';
+import FilterUrlSync from '@components/Providers/FilterUrlSync';
 import { useGlobalStyles } from '@styles/appStyles';
 import { useStyles } from './styles';
 import SideMenu from '../index';
@@ -10,6 +11,9 @@ const MenuLayout = ({ children }: { children: React.ReactNode }) => {
   useGlobalStyles();
   return (
     <FilterProvider>
+      <Suspense fallback={null}>
+        <FilterUrlSync />
+      </Suspense>
       <section className={styles.layoutWrapper}>
         <SideMenu />
         {children}

--- a/src/fabric_jumpstart_web/src/utils/filterTypes.ts
+++ b/src/fabric_jumpstart_web/src/utils/filterTypes.ts
@@ -1,0 +1,40 @@
+/** Pure types and constants for the catalog filter state — no React, safe to import in tests. */
+
+export interface FilterState {
+  search: string;
+  types: string[];
+  difficulties: string[];
+  workloadTags: string[];
+  scenarioTags: string[];
+  minMinutesToComplete: number | null;
+  maxMinutesToComplete: number | null;
+  classes: string[]; // empty = all, ['Core'] or ['Community'] to filter
+}
+
+export const emptyFilters: FilterState = {
+  search: '',
+  types: [],
+  difficulties: [],
+  workloadTags: [],
+  scenarioTags: [],
+  minMinutesToComplete: null,
+  maxMinutesToComplete: null,
+  classes: [],
+};
+
+export type SortOption =
+  | 'featured'
+  | 'newest'
+  | 'oldest'
+  | 'name-asc'
+  | 'name-desc'
+  | 'popularity';
+
+export const sortLabels: Record<SortOption, string> = {
+  featured: 'Featured first',
+  popularity: 'Most installed',
+  newest: 'Newest first',
+  oldest: 'Oldest first',
+  'name-asc': 'Name (A–Z)',
+  'name-desc': 'Name (Z–A)',
+};

--- a/src/fabric_jumpstart_web/src/utils/filterUrlSync.ts
+++ b/src/fabric_jumpstart_web/src/utils/filterUrlSync.ts
@@ -1,0 +1,59 @@
+import type { FilterState, SortOption } from '@utils/filterTypes';
+import { emptyFilters } from '@utils/filterTypes';
+
+const VALID_SORTS = new Set<SortOption>(['featured', 'newest', 'oldest', 'name-asc', 'name-desc', 'popularity']);
+
+/**
+ * Encodes active filters and sort into a URLSearchParams object.
+ * Only non-default values are written to keep URLs clean.
+ */
+export function filtersToSearchParams(filters: FilterState, sort: SortOption): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (filters.search) params.set('search', filters.search);
+  if (filters.types.length > 0) params.set('type', filters.types.join(','));
+  if (filters.difficulties.length > 0) params.set('difficulty', filters.difficulties.join(','));
+  if (filters.workloadTags.length > 0) params.set('workload', filters.workloadTags.join(','));
+  if (filters.scenarioTags.length > 0) params.set('scenario', filters.scenarioTags.join(','));
+  if (filters.classes.length > 0) params.set('class', filters.classes.join(','));
+  if (filters.minMinutesToComplete !== null) params.set('minTime', String(filters.minMinutesToComplete));
+  if (filters.maxMinutesToComplete !== null) params.set('maxTime', String(filters.maxMinutesToComplete));
+  if (sort !== 'featured') params.set('sort', sort);
+
+  return params;
+}
+
+/**
+ * Decodes URLSearchParams into filter state and sort option.
+ * Unknown or invalid values are silently ignored (safe fallback to defaults).
+ */
+export function searchParamsToFilters(
+  params: URLSearchParams
+): { filters: FilterState; sort: SortOption } {
+  const splitParam = (key: string): string[] => {
+    const raw = params.get(key);
+    return raw ? raw.split(',').map((v: string) => v.trim()).filter((v: string) => v.length > 0) : [];
+  };
+
+  const filters: FilterState = {
+    ...emptyFilters,
+    search: params.get('search') ?? '',
+    types: splitParam('type'),
+    difficulties: splitParam('difficulty'),
+    workloadTags: splitParam('workload'),
+    scenarioTags: splitParam('scenario'),
+    classes: splitParam('class'),
+    minMinutesToComplete: params.has('minTime') ? Number(params.get('minTime')) || null : null,
+    maxMinutesToComplete: params.has('maxTime') ? Number(params.get('maxTime')) || null : null,
+  };
+
+  const rawSort = params.get('sort') ?? '';
+  const sort: SortOption = VALID_SORTS.has(rawSort as SortOption) ? (rawSort as SortOption) : 'featured';
+
+  return { filters, sort };
+}
+
+/** Returns true if two URLSearchParams produce the same query string. */
+export function searchParamsEqual(a: URLSearchParams, b: URLSearchParams): boolean {
+  return a.toString() === b.toString();
+}


### PR DESCRIPTION
This pull request implements synchronization between the catalog filter state and the URL query parameters, improving shareability, deep linking, and state restoration for the catalog page. The main changes include adding a state-to-URL sync component, extracting filter types and helpers, and updating the UI to show loading skeletons until filter state is initialized from the URL.

**Catalog filter/URL synchronization:**
- Added a new `FilterUrlSync` component that keeps filter state and sort option in sync with the URL, both reading from the URL on mount and updating the URL when filters change. It uses a debounce for search and ensures no flash of unfiltered content by initializing state before paint. (`src/fabric_jumpstart_web/src/components/Providers/FilterUrlSync.tsx`, [[1]](diffhunk://#diff-68c6cfb467fcde7cf8b53931ab85b46cee02086c375eff10e4f0000a812c1df7R1-R59) [[2]](diffhunk://#diff-149ba9c075bea8347e507ebbadb5167e36ed7fb6d45043b11ab3de831b05a5daL2-R4) [[3]](diffhunk://#diff-149ba9c075bea8347e507ebbadb5167e36ed7fb6d45043b11ab3de831b05a5daR14-R16)
- Integrated `FilterUrlSync` into the catalog layout, wrapped in a React `Suspense` boundary to ensure proper operation with Next.js routing. (`src/fabric_jumpstart_web/src/components/SideMenu/MenuLayout/index.tsx`, [[1]](diffhunk://#diff-149ba9c075bea8347e507ebbadb5167e36ed7fb6d45043b11ab3de831b05a5daL2-R4) [[2]](diffhunk://#diff-149ba9c075bea8347e507ebbadb5167e36ed7fb6d45043b11ab3de831b05a5daR14-R16)

**Filter state management and types:**
- Extracted filter state types, empty state, and sort labels into a new `filterTypes.ts` utility for better testability and separation of concerns. (`src/fabric_jumpstart_web/src/utils/filterTypes.ts`, [src/fabric_jumpstart_web/src/utils/filterTypes.tsR1-R40](diffhunk://#diff-dc629ab0e90f44ff53842509e544a2faa75ec662aa5f5df169999c0358f393b3R1-R40))
- Updated the filter provider to use the new types and expose an `isInitialized` flag, which tracks when the filter state has been set from the URL. (`src/fabric_jumpstart_web/src/components/Providers/filterProvider.tsx`, [[1]](diffhunk://#diff-a7cee836b442ddd09be7a4791d377f2dd795e0da76fc2596a6c867ca8f4fa48cR4-R13) [[2]](diffhunk://#diff-a7cee836b442ddd09be7a4791d377f2dd795e0da76fc2596a6c867ca8f4fa48cR22-R32) [[3]](diffhunk://#diff-a7cee836b442ddd09be7a4791d377f2dd795e0da76fc2596a6c867ca8f4fa48cR56-R61)

**URL parameter helpers and tests:**
- Added pure helper functions for encoding/decoding filter state to/from URL parameters, with comprehensive unit tests to ensure round-trip correctness and robust handling of edge cases. (`src/fabric_jumpstart_web/src/utils/filterUrlSync.ts`, [[1]](diffhunk://#diff-68c6cfb467fcde7cf8b53931ab85b46cee02086c375eff10e4f0000a812c1df7R1-R59); `src/fabric_jumpstart_web/__tests__/filterUrlSync.test.ts`, [[2]](diffhunk://#diff-89bae135cbf506e99acc907c230906b87ac0e7e54c16bf09268acbfd1fb42d39R1-R187)

**Catalog UI improvements:**
- Updated the catalog grid to show loading skeletons until filter state is initialized from the URL, preventing flashes of unfiltered data and improving perceived performance. (`src/fabric_jumpstart_web/src/app/catalog/ScenarioGrid.tsx`, [[1]](diffhunk://#diff-b240e9429e6b712dcb27c164b3574e1086acfdf0eec7cac7066f05d7bd5e1bbfR14) [[2]](diffhunk://#diff-b240e9429e6b712dcb27c164b3574e1086acfdf0eec7cac7066f05d7bd5e1bbfL96-R97) [[3]](diffhunk://#diff-b240e9429e6b712dcb27c164b3574e1086acfdf0eec7cac7066f05d7bd5e1bbfL139-R149) [[4]](diffhunk://#diff-b240e9429e6b712dcb27c164b3574e1086acfdf0eec7cac7066f05d7bd5e1bbfL165-R173)

These changes together ensure that catalog filters are always reflected in the URL, enabling deep links, browser navigation, and a smooth user experience.


closes #136 