### PR TITLE
bug: diagram generator rendering not working on live site

### DIFF
--- a/src/fabric_jumpstart_web/src/components/MermaidDiagram/enhance.ts
+++ b/src/fabric_jumpstart_web/src/components/MermaidDiagram/enhance.ts
@@ -130,9 +130,9 @@ export function enhanceDiagram(
   const TYPE_COLOR = isDark ? 'rgba(180,190,200,0.7)' : 'rgba(80,90,100,0.75)';
 
   for (const g of root.querySelectorAll('g.node')) {
-    // Match by Mermaid node ID (e.g. id="flowchart-NB-0" → nodeId "NB")
+    // Match by Mermaid node ID (e.g. id="flowchart-NB-0" or "prefix-flowchart-NB-0" → nodeId "NB")
     const gId = g.getAttribute('id') ?? '';
-    const idMatch = gId.match(/^flowchart-(.+)-\d+$/);
+    const idMatch = gId.match(/flowchart-(.+)-\d+$/);
     const info = idMatch ? nodeMap.get(idMatch[1]) : undefined;
     if (!info) continue;
 


### PR DESCRIPTION
This pull request makes a small but important update to the logic for matching Mermaid node IDs in the `enhanceDiagram` function. The change improves compatibility with node IDs that may have a prefix before `flowchart-`.

This is required to restore rendering of nodes that are formatted