### PR TITLE
feat: add Getting Started with Data Agents jumpstart

### DIFF
--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
@@ -1,0 +1,33 @@
+id: 29
+logical_id: data-agent-l400
+name: Fabric Data Agent L400 Workshop
+description: >-
+  Build, govern, and evaluate a multi-source Fabric Data Agent using baseline
+  and AI-ready semantic models, a Lakehouse source, calibrated LLM judging,
+  fixed evaluation sets, and MLflow quality tracking.
+date_added: 08/11/2026
+include_in_listing: false
+workload_tags:
+  - Power BI
+  - Data Engineering
+  - Data Science
+scenario_tags:
+  - Modeling
+  - Monitoring
+  - Data Integration
+type: Tutorial
+source:
+  repo_url: https://github.com/pawarbi/fda-l400.git
+  repo_ref: v0.1.0-test
+  workspace_path: .
+items_in_scope:
+  - Notebook
+  - SemanticModel
+  - Report
+entry_point: WorkshopStart.Notebook
+test_suite: ""
+owner_email: sandeeppawar@microsoft.com
+minutes_to_deploy: 8
+minutes_to_complete_jumpstart: 180
+difficulty: Advanced
+last_updated: "2026-08-11"

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
@@ -18,7 +18,7 @@ scenario_tags:
 type: Tutorial
 source:
   repo_url: https://github.com/pawarbi/fda-l400.git
-  repo_ref: v1.0.0
+  repo_ref: v1.0.1
   workspace_path: data-agent-l400
 items_in_scope:
   - Notebook

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
@@ -2,11 +2,11 @@ id: 29
 logical_id: data-agent-l400
 name: Fabric Data Agent L400 Workshop
 description: >-
-  Build, govern, and evaluate a multi-source Fabric Data Agent using baseline
-  and AI-ready semantic models, a Lakehouse source, calibrated LLM judging,
-  fixed evaluation sets, and MLflow quality tracking.
-date_added: 08/11/2026
-include_in_listing: false
+  Learn to build, govern, and evaluate a multi-source Fabric Data Agent with
+  AI-ready semantic models, Lakehouse data, calibrated LLM judging, fixed
+  evaluation sets, and MLflow quality tracking.
+date_added: 08/16/2026
+include_in_listing: true
 workload_tags:
   - Power BI
   - Data Engineering
@@ -18,16 +18,13 @@ scenario_tags:
 type: Tutorial
 source:
   repo_url: https://github.com/pawarbi/fda-l400.git
-  repo_ref: v0.1.1-test
-  workspace_path: .
+  repo_ref: v1.0.0
+  workspace_path: data-agent-l400
 items_in_scope:
   - Notebook
-  - SemanticModel
-  - Report
-entry_point: WorkshopStart.Notebook
-test_suite: ""
-owner_email: sandeeppawar@microsoft.com
+entry_point: DataAgentGettingStarted.Notebook
+owner_email: jumpstart.data_agent@microsoft.com
 minutes_to_deploy: 8
 minutes_to_complete_jumpstart: 180
 difficulty: Advanced
-last_updated: "2026-08-11"
+last_updated: "2026-08-16"

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/community/data-agent-l400.yml
@@ -18,7 +18,7 @@ scenario_tags:
 type: Tutorial
 source:
   repo_url: https://github.com/pawarbi/fda-l400.git
-  repo_ref: v0.1.0-test
+  repo_ref: v0.1.1-test
   workspace_path: .
 items_in_scope:
   - Notebook

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/getting-started-data-agents.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/getting-started-data-agents.yml
@@ -18,7 +18,7 @@ scenario_tags:
 type: Tutorial
 source:
   repo_url: https://github.com/microsoft/fabric-data-agent-workshop.git
-  repo_ref: v1.0.3
+  repo_ref: v1.0.4
   workspace_path: getting-started-data-agents
 items_in_scope:
   - Notebook

--- a/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/getting-started-data-agents.yml
+++ b/src/fabric_jumpstart/fabric_jumpstart/jumpstarts/core/getting-started-data-agents.yml
@@ -1,8 +1,8 @@
 id: 29
-logical_id: data-agent-l400
-name: Fabric Data Agent L400 Workshop
+logical_id: getting-started-data-agents
+name: Getting Started with Data Agents
 description: >-
-  Learn to build, govern, and evaluate a multi-source Fabric Data Agent with
+  Build, govern, and evaluate a multi-source Data Agent with
   AI-ready semantic models, Lakehouse data, calibrated LLM judging, fixed
   evaluation sets, and MLflow quality tracking.
 date_added: 08/16/2026
@@ -17,14 +17,14 @@ scenario_tags:
   - Data Integration
 type: Tutorial
 source:
-  repo_url: https://github.com/pawarbi/fda-l400.git
-  repo_ref: v1.0.1
-  workspace_path: data-agent-l400
+  repo_url: https://github.com/microsoft/fabric-data-agent-workshop.git
+  repo_ref: v1.0.3
+  workspace_path: getting-started-data-agents
 items_in_scope:
   - Notebook
-entry_point: DataAgentGettingStarted.Notebook
+entry_point: SetupDataAgentJumpstart.Notebook
 owner_email: jumpstart.data_agent@microsoft.com
 minutes_to_deploy: 8
 minutes_to_complete_jumpstart: 180
 difficulty: Advanced
-last_updated: "2026-08-16"
+last_updated: "2026-08-28"

--- a/src/fabric_jumpstart_web/content/scenarios/getting-started-data-agents/index.mdx
+++ b/src/fabric_jumpstart_web/content/scenarios/getting-started-data-agents/index.mdx
@@ -75,6 +75,6 @@ After setup:
 
 ## Resources
 
-- [Source repository](https://github.com/microsoft/fabric-data-agent-workshop/tree/v1.0.3)
+- [Source repository](https://github.com/microsoft/fabric-data-agent-workshop/tree/v1.0.4)
 - [Microsoft Fabric Data Agent documentation](https://learn.microsoft.com/fabric/data-science/concept-data-agent)
 - [Evaluate your Data Agent](https://learn.microsoft.com/fabric/data-science/evaluate-data-agent)

--- a/src/fabric_jumpstart_web/content/scenarios/getting-started-data-agents/index.mdx
+++ b/src/fabric_jumpstart_web/content/scenarios/getting-started-data-agents/index.mdx
@@ -1,0 +1,79 @@
+---
+title: Getting Started with Data Agents
+toc: true
+---
+
+This tutorial walks through building, governing, extending, and evaluating a
+Microsoft Fabric Data Agent. It starts with a baseline semantic model and an
+AI-ready version of the same model, then adds a Lakehouse source and a
+repeatable evaluation workflow with calibrated LLM judging and MLflow.
+
+<Callout>
+
+Run `SetupDataAgentJumpstart` first. The Jumpstart deploys the notebooks, but
+the populated semantic models and reports require the post-deployment import
+performed by this notebook.
+
+</Callout>
+
+## What Gets Deployed
+
+The initial installation deploys six Python notebooks:
+
+| Notebook | Purpose |
+| --- | --- |
+| `SetupDataAgentJumpstart` | Required entry point. Imports, organizes, and validates the populated semantic models and reports. |
+| `RefreshSemanticModel` | Optional maintenance for refreshing or repairing the semantic model Web connection. |
+| `BuildOpsRefData` | Creates the schema-enabled `OpsRefData` Lakehouse and its supported Data Agent interface. |
+| `CreateMultiSourceDataAgent` | Adds the Lakehouse source and publishes a multi-source Data Agent. |
+| `JudgeCalibration` | Calibrates and registers the LLM judge used for evaluation. |
+| `EvaluateDataAgent` | Evaluates Data Agent responses and records quality results in MLflow. |
+
+`SetupDataAgentJumpstart` imports these additional assets from immutable,
+hash-validated PBIX files:
+
+| Item | Type | Role |
+| --- | --- | --- |
+| `ManufacturingOps` | Semantic model and report | Baseline model used for comparison. |
+| `ManufacturingOpsAIReady` | Semantic model and report | AI-ready model used to create the initial Data Agent. |
+
+## Required First Step
+
+Open `SetupDataAgentJumpstart`, review its parameter cell, and select **Run
+all**. The tested defaults point to the immutable release used by the catalog.
+The notebook then:
+
+1. Downloads both PBIX assets and validates their SHA-256 hashes.
+2. Imports the reports and semantic models with `CreateOrOverwrite`.
+3. Moves every imported item into the `getting-started-data-agents` folder.
+4. Queries both semantic models to verify that populated data is available.
+
+Do not continue until the notebook prints its final success message. Rerunning
+the notebook is safe and replaces the same-named imported items.
+
+## Learning Path
+
+After setup:
+
+1. Compare the `ManufacturingOps` and `ManufacturingOpsAIReady` reports and
+   semantic models.
+2. Create and publish a Data Agent using `ManufacturingOpsAIReady`.
+3. Run `BuildOpsRefData` to create a Lakehouse source.
+4. Run `CreateMultiSourceDataAgent` to add that source to a new Data Agent.
+5. Run `JudgeCalibration` to register a calibrated evaluator.
+6. Run `EvaluateDataAgent` to score responses and inspect MLflow results.
+
+## Requirements
+
+- A Microsoft Fabric capacity and tenant that support notebooks, semantic
+  models, reports, Data Agents, Lakehouses, and MLflow.
+- Contributor or higher access to the target workspace.
+- Permission to create and publish Data Agents and Fabric connections.
+- Outbound access to `raw.githubusercontent.com`.
+- Delegated `Workspace.ReadWrite.All` permission for folder placement.
+
+## Resources
+
+- [Source repository](https://github.com/microsoft/fabric-data-agent-workshop/tree/v1.0.3)
+- [Microsoft Fabric Data Agent documentation](https://learn.microsoft.com/fabric/data-science/concept-data-agent)
+- [Evaluate your Data Agent](https://learn.microsoft.com/fabric/data-science/evaluate-data-agent)

--- a/src/fabric_jumpstart_web/content/scenarios/getting-started-data-agents/index.mdx
+++ b/src/fabric_jumpstart_web/content/scenarios/getting-started-data-agents/index.mdx
@@ -39,14 +39,15 @@ hash-validated PBIX files:
 
 ## Required First Step
 
-Open `SetupDataAgentJumpstart`, review its parameter cell, and select **Run
-all**. The tested defaults point to the immutable release used by the catalog.
-The notebook then:
+Open `SetupDataAgentJumpstart` and select **Run all without changing any
+values**. The tested defaults point to the immutable release used by the
+catalog. The notebook then:
 
 1. Downloads both PBIX assets and validates their SHA-256 hashes.
 2. Imports the reports and semantic models with `CreateOrOverwrite`.
 3. Moves every imported item into the `getting-started-data-agents` folder.
-4. Queries both semantic models to verify that populated data is available.
+4. Updates both semantic models to use the Microsoft-hosted data source.
+5. Queries both semantic models to verify that populated data is available.
 
 Do not continue until the notebook prints its final success message. Rerunning
 the notebook is safe and replaces the same-named imported items.


### PR DESCRIPTION
# Why this change is needed

Adds **Getting Started with Data Agents** as a core Jumpstart with Microsoft-owned source, a catalog context page, and a guided post-deployment setup experience.

# How

- Registers core Jumpstart ID 29 with logical ID `getting-started-data-agents`.
- Uses Microsoft-owned source [`microsoft/fabric-data-agent-workshop`](https://github.com/microsoft/fabric-data-agent-workshop) pinned to immutable release [`v1.0.3`](https://github.com/microsoft/fabric-data-agent-workshop/tree/v1.0.3).
- Deploys six Python notebooks from workspace path `getting-started-data-agents`.
- Opens `SetupDataAgentJumpstart.Notebook` as the entry point.
- The setup notebook tells participants to run it without changing values, imports and validates both populated PBIX assets, moves the resulting reports and semantic models into the Jumpstart folder, updates their `DataFolder` parameters to the Microsoft-hosted source, and verifies populated data with DAX.
- Adds `content/scenarios/getting-started-data-agents/index.mdx` with the deployment inventory, required first step, learning path, requirements, and resources.
- Preserves the Microsoft repository governance files, including the Microsoft license, security policy, support policy, and code of conduct.

# Test

- `python -m pytest tests/test_registry.py -q` — 36 passed.
- Confirmed `microsoft/fabric-data-agent-workshop@v1.0.3` resolves and contains the expected `getting-started-data-agents` workspace path and entry notebook.
- Confirmed both PBIX assets, workshop data, evaluation workbook, and workshop PDF return HTTP 200 from the immutable Microsoft release.
- Confirmed generated notebook platform JSON parses, setup and refresh notebook Python cells parse, and no current source files reference `pawarbi/fda-l400`.

# Closes issue

Fixes #208
